### PR TITLE
liron's `ButteredBread` fixes

### DIFF
--- a/src/ButteredBread.sol
+++ b/src/ButteredBread.sol
@@ -135,14 +135,14 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, OwnableUpgradea
 
     /// @notice Deposit LP tokens and mint ButteredBread with corresponding LP scaling factor
     function _deposit(address _account, address _lp, uint256 _amount) internal {
-        require(IERC20(_lp).transferFrom(_account, address(this), _amount), "Transfer failed");
+        _syncDelegation(_account);
         _accountToLPData[_account][_lp].balance += _amount;
 
         uint256 currentScalingFactor = scalingFactors[_lp];
         _accountToLPData[_account][_lp].scalingFactor = currentScalingFactor;
 
         _mint(_account, _amount * currentScalingFactor / FIXED_POINT_PERCENT);
-        _syncDelegation(_account);
+        require(IERC20(_lp).transferFrom(_account, address(this), _amount), "Transfer failed");
 
         emit ButterAdded(_account, _lp, _amount);
     }

--- a/src/ButteredBread.sol
+++ b/src/ButteredBread.sol
@@ -5,6 +5,8 @@ import {OwnableUpgradeable} from "openzeppelin-contracts-upgradeable/contracts/a
 import {ERC20VotesUpgradeable} from
     "openzeppelin-contracts-upgradeable/contracts/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {ReentrancyGuardUpgradeable} from
+    "openzeppelin-contracts-upgradeable/contracts/utils/ReentrancyGuardUpgradeable.sol";
 
 import {IButteredBread} from "src/interfaces/IButteredBread.sol";
 import {IERC20Votes} from "src/interfaces/IERC20Votes.sol";
@@ -17,7 +19,7 @@ import {IERC20Votes} from "src/interfaces/IERC20Votes.sol";
  * @custom:coauthor @daopunk
  * @custom:coauthor @bagelface
  */
-contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, OwnableUpgradeable {
+contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, OwnableUpgradeable, ReentrancyGuardUpgradeable {
     /// @notice Value used for calculating the precision of scaling factors
     uint256 public constant FIXED_POINT_PERCENT = 100;
     /// @notice `IERC20Votes` contract used for powering `ButteredBread` voting
@@ -47,6 +49,8 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, OwnableUpgradea
 
         __Ownable_init(msg.sender);
         __ERC20_init(_initData.name, _initData.symbol);
+        __ERC20Votes_init();
+        __ReentrancyGuard_init();
 
         for (uint256 i; i < _initData.liquidityPools.length; ++i) {
             scalingFactors[_initData.liquidityPools[i]] = _initData.scalingFactors[i];
@@ -75,7 +79,7 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, OwnableUpgradea
      * @param _lp Liquidity Pool token
      * @param _amount Value of LP token
      */
-    function deposit(address _lp, uint256 _amount) external onlyAllowed(_lp) {
+    function deposit(address _lp, uint256 _amount) external onlyAllowed(_lp) nonReentrant {
         if (_amount == 0) revert AmountZero();
         _deposit(msg.sender, _lp, _amount);
     }

--- a/src/ButteredBread.sol
+++ b/src/ButteredBread.sol
@@ -125,10 +125,10 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, OwnableUpgradea
         revert NonDelegatable();
     }
 
-    /// @notice Get the balance of a specific LP for a given account
-    /// @param _holder The address of the account to get the balance for
-    /// @param _lp The address of the LP to get the balance for
-    /// @return LPData memory The balance of the LP for the given account
+    /// @notice Get the balance and scaling factor of a specific LP for a given account
+    /// @param _holder The address of the account to get the data for
+    /// @param _lp The address of the LP to get the data for
+    /// @return LPData memory The balance and scaling factor of the LP for the given account
     function balanceOfLP(address _holder, address _lp) external view returns (LPData memory) {
         return _accountToLPData[_holder][_lp];
     }

--- a/src/ButteredBread.sol
+++ b/src/ButteredBread.sol
@@ -136,12 +136,12 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, OwnableUpgradea
     /// @notice Deposit LP tokens and mint ButteredBread with corresponding LP scaling factor
     function _deposit(address _account, address _lp, uint256 _amount) internal {
         _syncDelegation(_account);
+
+        /// @dev ensure proper accounting in case of admin error in `modifyScalingFactor` where not all holders are updated
+        _syncVotingWeight(_account, _lp);
         _accountToLPData[_account][_lp].balance += _amount;
-
-        uint256 currentScalingFactor = scalingFactors[_lp];
-        _accountToLPData[_account][_lp].scalingFactor = currentScalingFactor;
-
-        _mint(_account, _amount * currentScalingFactor / FIXED_POINT_PERCENT);
+        
+        _mint(_account, _amount * scalingFactors[_lp] / FIXED_POINT_PERCENT);
         require(IERC20(_lp).transferFrom(_account, address(this), _amount), "Transfer failed");
 
         emit ButterAdded(_account, _lp, _amount);

--- a/src/ButteredBread.sol
+++ b/src/ButteredBread.sol
@@ -90,7 +90,7 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, OwnableUpgradea
      * @param _lp Liquidity Pool token
      * @param _amount Value of LP token
      */
-    function withdraw(address _lp, uint256 _amount) external onlyAllowed(_lp) {
+    function withdraw(address _lp, uint256 _amount) external onlyAllowed(_lp) nonReentrant {
         if (_amount == 0) revert AmountZero();
         _withdraw(msg.sender, _lp, _amount);
     }

--- a/src/ButteredBread.sol
+++ b/src/ButteredBread.sol
@@ -75,7 +75,7 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, OwnableUpgradea
      * @param _amount Value of LP token
      */
     function deposit(address _lp, uint256 _amount) external onlyAllowed(_lp) {
-        require(_amount != 0, "Amount must be greater than 0");
+        if (_amount == 0) revert AmountZero();
         _deposit(msg.sender, _lp, _amount);
     }
 
@@ -85,7 +85,7 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, OwnableUpgradea
      * @param _amount Value of LP token
      */
     function withdraw(address _lp, uint256 _amount) external onlyAllowed(_lp) {
-        require(_amount != 0, "Amount must be greater than 0");
+        if (_amount == 0) revert AmountZero();
         _withdraw(msg.sender, _lp, _amount);
     }
 
@@ -143,7 +143,9 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, OwnableUpgradea
         _accountToLPData[_account][_lp].balance += _amount;
         
         _mint(_account, _amount * scalingFactors[_lp] / FIXED_POINT_PERCENT);
-        require(IERC20(_lp).transferFrom(_account, address(this), _amount), "Transfer failed");
+        
+        bool success = IERC20(_lp).transferFrom(_account, address(this), _amount);
+        if (!success) revert TransferFailed();
 
         emit ButterAdded(_account, _lp, _amount);
     }
@@ -158,7 +160,8 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, OwnableUpgradea
         _accountToLPData[_account][_lp].balance -= _amount;
 
         _burn(_account, _amount * scalingFactors[_lp] / FIXED_POINT_PERCENT);
-        require(IERC20(_lp).transfer(_account, _amount), "Transfer failed");
+        bool success = IERC20(_lp).transfer(_account, _amount);
+        if (!success) revert TransferFailed();
 
         emit ButterRemoved(_account, _lp, _amount);
     }

--- a/src/ButteredBread.sol
+++ b/src/ButteredBread.sol
@@ -92,6 +92,7 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, OwnableUpgradea
     /**
      * @notice Allow or deny LP token
      * @dev Must set scaling factor before sanctioning LP token
+     * @dev WARNING: When adding a new LP token, ensure that it has 18 decimals
      * @param _lp Liquidity Pool token
      * @param _allowed Sanction status of LP token
      */

--- a/src/ButteredBread.sol
+++ b/src/ButteredBread.sol
@@ -70,7 +70,8 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, OwnableUpgradea
     }
 
     /**
-     * @notice Deposit LP tokens
+     * @notice Deposit LP tokens and mint ButteredBread
+     *  NOTE: Additional ButteredBread can be minted/burned due to scaling factor changes
      * @param _lp Liquidity Pool token
      * @param _amount Value of LP token
      */
@@ -80,7 +81,8 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, OwnableUpgradea
     }
 
     /**
-     * @notice Withdraw LP tokens
+     * @notice Withdraw LP tokens and burn ButteredBread
+     *  NOTE: Additional ButteredBread can be minted/burned due to scaling factor changes
      * @param _lp Liquidity Pool token
      * @param _amount Value of LP token
      */

--- a/src/ButteredBread.sol
+++ b/src/ButteredBread.sol
@@ -75,6 +75,7 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, OwnableUpgradea
      * @param _amount Value of LP token
      */
     function deposit(address _lp, uint256 _amount) external onlyAllowed(_lp) {
+        require(_amount != 0, "Amount must be greater than 0");
         _deposit(msg.sender, _lp, _amount);
     }
 
@@ -84,6 +85,7 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, OwnableUpgradea
      * @param _amount Value of LP token
      */
     function withdraw(address _lp, uint256 _amount) external onlyAllowed(_lp) {
+        require(_amount != 0, "Amount must be greater than 0");
         _withdraw(msg.sender, _lp, _amount);
     }
 

--- a/src/ButteredBread.sol
+++ b/src/ButteredBread.sol
@@ -138,16 +138,16 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, OwnableUpgradea
 
     /// @notice Deposit LP tokens and mint ButteredBread with corresponding LP scaling factor
     function _deposit(address _account, address _lp, uint256 _amount) internal {
+        bool success = IERC20(_lp).transferFrom(_account, address(this), _amount);
+        if (!success) revert TransferFailed();
+
         _syncDelegation(_account);
 
         /// @dev ensure proper accounting in case of admin error in `modifyScalingFactor` where not all holders are updated
         _syncVotingWeight(_account, _lp);
         _accountToLPData[_account][_lp].balance += _amount;
-        
+
         _mint(_account, _amount * scalingFactors[_lp] / FIXED_POINT_PERCENT);
-        
-        bool success = IERC20(_lp).transferFrom(_account, address(this), _amount);
-        if (!success) revert TransferFailed();
 
         emit ButterAdded(_account, _lp, _amount);
     }

--- a/src/ButteredBread.sol
+++ b/src/ButteredBread.sol
@@ -135,7 +135,7 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, OwnableUpgradea
 
     /// @notice Deposit LP tokens and mint ButteredBread with corresponding LP scaling factor
     function _deposit(address _account, address _lp, uint256 _amount) internal {
-        IERC20(_lp).transferFrom(_account, address(this), _amount);
+        require(IERC20(_lp).transferFrom(_account, address(this), _amount), "Transfer failed");
         _accountToLPData[_account][_lp].balance += _amount;
 
         uint256 currentScalingFactor = scalingFactors[_lp];
@@ -157,7 +157,7 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, OwnableUpgradea
         _accountToLPData[_account][_lp].balance -= _amount;
 
         _burn(_account, _amount * scalingFactors[_lp] / FIXED_POINT_PERCENT);
-        IERC20(_lp).transfer(_account, _amount);
+        require(IERC20(_lp).transfer(_account, _amount), "Transfer failed");
 
         emit ButterRemoved(_account, _lp, _amount);
     }

--- a/src/interfaces/IButteredBread.sol
+++ b/src/interfaces/IButteredBread.sol
@@ -17,6 +17,10 @@ interface IButteredBread {
     error NonTransferable();
     /// @notice Occurs when a dependent variable is not set
     error UnsetVariable();
+    /// @notice Occurs when a transfer fails
+    error TransferFailed();
+    /// @notice Occurs when an amount is 0
+    error AmountZero();
 
     /// @notice The event emitted when an LP Token (Butter) has been added
     event ButterAdded(address _account, address _lp, uint256 _amount);


### PR DESCRIPTION
for #119 i've implemented the simple solution but you could also just make sure you've iterated over all users and that way you don't need to pass an array of users to update and don't need to keep scaling factor per user in the contract or to sync voting weights.

for #117 i've just added a warning, as decided by @RonTuretzky