### PR TITLE
fix: rename balanceOfLP to getLPData to fix naming mismatch (#118)

### DIFF
--- a/src/ButteredBread.sol
+++ b/src/ButteredBread.sol
@@ -132,11 +132,11 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, Ownable2StepUpg
         revert NonDelegatable();
     }
 
-    /// @notice Get the balance and scaling factor of a specific LP for a given account
+    /// @notice Get the LP data (balance and scaling factor) of a specific LP for a given account
     /// @param _holder The address of the account to get the data for
     /// @param _lp The address of the LP to get the data for
-    /// @return LPData memory The balance and scaling factor of the LP for the given account
-    function balanceOfLP(address _holder, address _lp) external view returns (LPData memory) {
+    /// @return LPData memory The LP data containing balance and scaling factor for the given account
+    function getLPData(address _holder, address _lp) external view returns (LPData memory) {
         return _accountToLPData[_holder][_lp];
     }
 


### PR DESCRIPTION
## Summary
- Renamed `balanceOfLP` function to `getLPData` to accurately reflect its return type
- Updated function documentation to clarify it returns complete LP data structure (balance + scaling factor)
- Resolves naming confusion between `balanceOfLP` and `accountToLPBalance`

## Changes
- `src/ButteredBread.sol`: Renamed function and updated natspec documentation

## Test plan
- [x] All existing tests pass (verified with `forge test`)
- [x] No breaking changes to test suite
- [x] Function name now accurately describes its behavior

The function was previously named `balanceOfLP` but returned an `LPData` struct containing both balance and scaling factor, which was misleading. The separate `accountToLPBalance` function already provides access to just the balance value.

🤖 Generated with [Claude Code](https://claude.ai/code)