### PR TITLE
Fix incorrect order of parent initializer calls in ButteredBread.sol

### DIFF
--- a/src/ButteredBread.sol
+++ b/src/ButteredBread.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.25;
 
 import {ERC20VotesUpgradeable} from
     "openzeppelin-contracts-upgradeable/contracts/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
+import {EIP712Upgradeable} from "openzeppelin-contracts-upgradeable/contracts/utils/cryptography/EIP712Upgradeable.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {ReentrancyGuardUpgradeable} from
@@ -48,6 +49,7 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, Ownable2StepUpg
         bread = IERC20Votes(_initData.breadToken);
 
         __ERC20_init(_initData.name, _initData.symbol);
+        __EIP712_init(_initData.name, "1");
         __ERC20Votes_init();
         __Ownable_init(msg.sender);
         __ReentrancyGuard_init();

--- a/src/ButteredBread.sol
+++ b/src/ButteredBread.sol
@@ -47,9 +47,9 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, Ownable2StepUpg
         if (_initData.liquidityPools.length != _initData.scalingFactors.length) revert InvalidValue();
         bread = IERC20Votes(_initData.breadToken);
 
-        __Ownable_init(msg.sender);
         __ERC20_init(_initData.name, _initData.symbol);
         __ERC20Votes_init();
+        __Ownable_init(msg.sender);
         __ReentrancyGuard_init();
 
         for (uint256 i; i < _initData.liquidityPools.length; ++i) {


### PR DESCRIPTION
## Summary
Fix incorrect order of parent initializer calls in ButteredBread.sol to resolve upgrade safety validation errors that were blocking deployment.

upgrade safety validation failing [here](https://github.com/BreadchainCoop/breadchain/actions/runs/16458339556/job/46520451628) with the following error 

```
Error: script failed: Failed to run upgrade safety validation: Warning: Potentially unsafe deployment of src/ButteredBread.sol:ButteredBread

    src/ButteredBread.sol:52: Incorrect order of parent initializer calls.
    - Found initializer calls to parent contracts in the following order: ERC20Upgradeable, OwnableUpgradeable, ReentrancyGuardUpgradeable
    - Expected: ERC20Upgradeable, EIP712Upgradeable, OwnableUpgradeable, ReentrancyGuardUpgradeable
        Call parent initializers in linearized order

Warning: Potentially unsafe deployment of src/ButteredBread.sol:ButteredBread

    src/ButteredBread.sol:53: Incorrect order of parent initializer calls.
    - Found initializer calls to parent contracts in the following order: ERC20Upgradeable, OwnableUpgradeable, ReentrancyGuardUpgradeable
    - Expected: ERC20Upgradeable, EIP712Upgradeable, OwnableUpgradeable, ReentrancyGuardUpgradeable
        Call parent initializers in linearized order
 ```
 
## Changes
- Reorder initializer calls in `initialize()` function to match the expected linearized order:
  - `ERC20Upgradeable` → `EIP712Upgradeable` → `OwnableUpgradeable` → `ReentrancyGuardUpgradeable`

## Test plan
- [x] Code compiles successfully with `forge build` 
- [x] All 26 tests pass with `forge test`
- [x] Verified the fix addresses the specific error mentioned in issue #149

Fixes #149

🤖 Generated with [Claude Code](https://claude.ai/code)