### PR TITLE
Refactor OpenZeppelin library remappings

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,9 +1,6 @@
 bread-token/=lib/bread-token-v2/
 forge-std/=lib/forge-std/src/
-openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/
-openzeppelin-contracts/=lib/openzeppelin-contracts/
-lib/openzeppelin-contracts:@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
-lib/openzeppelin-contracts-upgradeable:@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
-lib/openzeppelin-contracts-upgradeable:@openzeppelin/contracts/=lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/
-@openzeppelin/contracts/=lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
 @openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
+openzeppelin-contracts/=lib/openzeppelin-contracts/
+openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/

--- a/script/deploy/DeployButteredBread.s.sol
+++ b/script/deploy/DeployButteredBread.s.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.25;
 import "forge-std/Script.sol";
 import "forge-std/StdJson.sol";
 import "forge-std/console.sol";
-import "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {GNOSIS_BREAD} from "script/Constants.s.sol";
 import {ButteredBread, IButteredBread} from "src/ButteredBread.sol";
 

--- a/script/deploy/DeployVotingStreakMultiplier.s.sol
+++ b/script/deploy/DeployVotingStreakMultiplier.s.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 import "forge-std/Script.sol";
 import "forge-std/StdJson.sol";
 import "forge-std/console.sol";
-import "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 import {VotingStreakMultiplier} from "../../src/multipliers/VotingStreakMultiplier.sol";
 

--- a/script/deploy/DeployYieldDistributor.s.sol
+++ b/script/deploy/DeployYieldDistributor.s.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.20;
 import "forge-std/Script.sol";
 import "forge-std/StdJson.sol";
 import "forge-std/console.sol";
-import "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import "openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 import {YieldDistributor} from "../../src/YieldDistributor.sol";
 

--- a/src/ButteredBread.sol
+++ b/src/ButteredBread.sol
@@ -2,11 +2,11 @@
 pragma solidity 0.8.25;
 
 import {ERC20VotesUpgradeable} from
-    "openzeppelin-contracts-upgradeable/contracts/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
+    "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
-import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ReentrancyGuardUpgradeable} from
-    "openzeppelin-contracts-upgradeable/contracts/utils/ReentrancyGuardUpgradeable.sol";
+    "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 
 import {IButteredBread} from "src/interfaces/IButteredBread.sol";
 import {IERC20Votes} from "src/interfaces/IERC20Votes.sol";

--- a/src/VotingMultipliers.sol
+++ b/src/VotingMultipliers.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.22;
 
-import {Ownable2StepUpgradeable} from "openzeppelin-contracts-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
-import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {IVotingMultipliers, IMultiplier} from "src/interfaces/IVotingMultipliers.sol";
 import {MultiplierConstants} from "src/libraries/MultiplierConstants.sol";
 

--- a/src/YieldDistributor.sol
+++ b/src/YieldDistributor.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.22;
 
-import {Ownable2StepUpgradeable} from "openzeppelin-contracts-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {Checkpoints} from
-    "openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/utils/structs/Checkpoints.sol";
+    "@openzeppelin/contracts/utils/structs/Checkpoints.sol";
 import {ERC20VotesUpgradeable} from
-    "openzeppelin-contracts-upgradeable/contracts/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
+    "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
 import {Bread} from "bread-token/src/Bread.sol";
 
 import {IYieldDistributor} from "src/interfaces/IYieldDistributor.sol";

--- a/src/interfaces/ICurveStableSwap.sol
+++ b/src/interfaces/ICurveStableSwap.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.25;
 
-import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface ICurveStableSwap is IERC20 {
     /**

--- a/src/interfaces/IERC20Votes.sol
+++ b/src/interfaces/IERC20Votes.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.25;
 
-import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface IERC20Votes is IERC20 {
     /**

--- a/test/ButteredBread.t.sol
+++ b/test/ButteredBread.t.sol
@@ -6,8 +6,8 @@ import "forge-std/StdJson.sol";
 import "forge-std/StdUtils.sol";
 import {Test} from "forge-std/Test.sol";
 import {TransparentUpgradeableProxy} from
-    "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+    "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {ButteredBread, IButteredBread} from "src/ButteredBread.sol";
 import {ICurveStableSwap} from "src/interfaces/ICurveStableSwap.sol";
@@ -15,8 +15,8 @@ import {IERC20Votes} from "src/interfaces/IERC20Votes.sol";
 import {YieldDistributorTestWrapper} from "src/test/YieldDistributorTestWrapper.sol";
 import {YieldDistributor, IYieldDistributor} from "src/YieldDistributor.sol";
 import {IBread} from "bread-token/src/interfaces/IBread.sol";
-import {Ownable2StepUpgradeable} from "openzeppelin-contracts-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
-import {ERC20Mock} from "openzeppelin-contracts/contracts/mocks/token/ERC20Mock.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 
 uint256 constant XDAI_FACTOR = 700; // 700% scaling factor; 7X
 uint256 constant TOKEN_AMOUNT = 1000 ether;

--- a/test/YieldDistributor.t.sol
+++ b/test/YieldDistributor.t.sol
@@ -5,11 +5,11 @@ import {Test, console2} from "forge-std/Test.sol";
 import "forge-std/StdJson.sol";
 
 import {ERC20VotesUpgradeable} from
-    "openzeppelin-contracts-upgradeable/contracts/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
-import {Ownable2StepUpgradeable} from "openzeppelin-contracts-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
+    "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {TransparentUpgradeableProxy} from
-    "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {IERC721} from "openzeppelin-contracts/contracts/token/ERC721/IERC721.sol";
+    "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import {YieldDistributor, IYieldDistributor} from "src/YieldDistributor.sol";

--- a/test/upgrades/v1.0.0/YieldDistributor.sol
+++ b/test/upgrades/v1.0.0/YieldDistributor.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.22;
 
-import {OwnableUpgradeable} from "openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {Checkpoints} from
-    "openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/utils/structs/Checkpoints.sol";
+    "@openzeppelin/contracts/utils/structs/Checkpoints.sol";
 import {Bread} from "bread-token/src/Bread.sol";
 
 /**

--- a/test/upgrades/v1.0.1/YieldDistributor.sol
+++ b/test/upgrades/v1.0.1/YieldDistributor.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.22;
 
-import {OwnableUpgradeable} from "openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {Checkpoints} from
-    "openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/utils/structs/Checkpoints.sol";
+    "@openzeppelin/contracts/utils/structs/Checkpoints.sol";
 import {Bread} from "bread-token/src/Bread.sol";
 
 /**


### PR DESCRIPTION
## Summary
Refactors OpenZeppelin library remappings to improve code readability and consistency as requested in #130.

• Simplified `remappings.txt` from 9 confusing entries to 6 clean, standardized ones
• Standardized all imports to use `@openzeppelin/contracts/` and `@openzeppelin/contracts-upgradeable/` patterns
• Updated 13 files across contracts, tests, and deployment scripts
• Maintained backward compatibility while significantly improving code consistency

## Test plan
- [x] All contracts compile successfully with `forge build`
- [x] Tests run without errors (verified compilation and initial test runs)
- [x] No breaking changes to existing functionality

Fixes #130

🤖 Generated with [Claude Code](https://claude.ai/code)