### PR TITLE
fix: use addr() to generate addresses from a seed value

### DIFF
--- a/test/YieldDistributor.t.sol
+++ b/test/YieldDistributor.t.sol
@@ -235,7 +235,7 @@ contract YieldDistributorTest is Test {
             // Generating random values for the test
             uint256 randomval = uint256(keccak256(abi.encodePacked(seed, i)));
             uint256 vote = randomval % 100;
-            address holder = address(uint160(randomval));
+            address holder = vm.addr(randomval);
             uint256 token_amount = bound(randomval, _minVotingAmount, 1000 * _minVotingAmount);
 
             // Setting up the account for voting


### PR DESCRIPTION
The fuzzer generates random values that create addresses that have never been "touched" in the EVM state.
1. EVM State Management: When you call `vm.deal(address, amount)` on an address that has never been used before, Foundry needs to create an account for that address in the EVM state. However, if the address hasn't been properly initialized or labeled, the EVM state management can fail.
2. Fork Mode Complications: Since your test is using `vm.createSelectFork(vm.rpcUrl("gnosis"))`, you're working with a forked environment. In fork mode, Foundry is more strict about address state management because it's trying to maintain consistency with the real blockchain state.

Using `addr()` instead of just casting an `uint256` value to an address type should properly initialize the addresses.