### PR TITLE
Remove minimum voting power requirement

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,13 +2,7 @@ name: test
 
 on:
   push:
-    branches:
-      - main
-      - dev
   pull_request:
-    branches:
-      - main
-      - dev
   workflow_dispatch:
 
 jobs:

--- a/script/deploy/DeployYieldDistributor.s.sol
+++ b/script/deploy/DeployYieldDistributor.s.sol
@@ -13,7 +13,6 @@ contract DeployYieldDistributor is Script {
     string config_data = vm.readFile(deployConfigPath);
     address _bread = stdJson.readAddress(config_data, "._bread");
     address _butteredBread = stdJson.readAddress(config_data, "._butteredBread");
-    uint256 _minRequiredVotingPower = stdJson.readUint(config_data, "._minRequiredVotingPower");
     uint256 _cycleLength = stdJson.readUint(config_data, "._cycleLength");
     uint256 _maxPoints = stdJson.readUint(config_data, "._maxPoints");
     uint256 _precision = stdJson.readUint(config_data, "._precision");
@@ -27,12 +26,12 @@ contract DeployYieldDistributor is Script {
         _bread,
         _butteredBread,
         _precision,
-        _minRequiredVotingPower,
         _maxPoints,
         _cycleLength,
         _yieldFixedSplitDivisor,
         _lastClaimedBlockNumber,
-        projects
+        projects,
+        _owner
     );
 
     function run() external {

--- a/script/deploy/config/deployYD.json
+++ b/script/deploy/config/deployYD.json
@@ -19,7 +19,6 @@
     "_blocktime": 5,
     "_maxPoints": 10000,
     "_cycleLength": 518400,
-    "_minRequiredVotingPower": 1728000000000000000000000,
     "_lastClaimedBlockNumber": 1,
     "_precision": 1000000000000000000,
     "_yieldFixedSplitDivisor": 2

--- a/src/YieldDistributor.sol
+++ b/src/YieldDistributor.sol
@@ -33,8 +33,6 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
     uint256 public cycleLength;
     /// @notice The maximum number of points a voter can allocate to a project
     uint256 public maxPoints;
-    /// @notice The minimum required voting power participants must have to cast a vote
-    uint256 public minRequiredVotingPower;
     /// @notice The block number of the last yield distribution
     uint256 public lastClaimedBlockNumber;
     /// @notice The total voting power accumulated in the current cycle
@@ -73,25 +71,26 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
         address _bread,
         address _butteredBread,
         uint256 _precision,
-        uint256 _minRequiredVotingPower,
         uint256 _maxPoints,
         uint256 _cycleLength,
         uint256 _yieldFixedSplitDivisor,
         uint256 _lastClaimedBlockNumber,
-        address[] memory _projects
+        address[] memory _projects,
+        address _initialOwner
     ) public initializer {
         if (
-            _bread == address(0) || _butteredBread == address(0) || _precision == 0 || _minRequiredVotingPower == 0
-                || _maxPoints == 0 || _cycleLength == 0 || _yieldFixedSplitDivisor == 0 || _lastClaimedBlockNumber == 0
-                || _projects.length == 0
+            _bread == address(0) || _butteredBread == address(0) || _precision == 0 || _maxPoints == 0
+                || _cycleLength == 0 || _yieldFixedSplitDivisor == 0 || _lastClaimedBlockNumber == 0
+                || _projects.length == 0 || _initialOwner == address(0)
         ) {
             revert MustBeGreaterThanZero();
         }
 
+        __VotingMultipliers_init(_initialOwner);
+
         BREAD = IBread(_bread);
         BUTTERED_BREAD = IERC20Votes(_butteredBread);
         PRECISION = _precision;
-        minRequiredVotingPower = _minRequiredVotingPower;
         maxPoints = _maxPoints;
         cycleLength = _cycleLength;
         yieldFixedSplitDivisor = _yieldFixedSplitDivisor;
@@ -291,8 +290,6 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
     function castVote(uint256[] calldata _points) public trackState {
         uint256 _currentVotingPower = getCurrentVotingPower(msg.sender);
 
-        if (_currentVotingPower < minRequiredVotingPower) revert BelowMinRequiredVotingPower();
-
         _castVote(msg.sender, _points, _currentVotingPower);
     }
 
@@ -308,7 +305,6 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
         uint256 _currentVotingPower = getCurrentVotingPower(msg.sender);
         uint256 _multiplier = calculateTotalMultipliers(msg.sender, _multiplierIndices);
         _currentVotingPower = _multiplier == 0 ? _currentVotingPower : (_currentVotingPower * _multiplier) / PRECISION;
-        if (_currentVotingPower < minRequiredVotingPower) revert BelowMinRequiredVotingPower();
 
         _castVote(msg.sender, _points, _currentVotingPower);
     }
@@ -475,16 +471,6 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
         }
 
         queuedProjectsForRemoval.push(_project);
-    }
-
-    /**
-     * @notice Set a new minimum required voting power a user must have to vote
-     * @param _minRequiredVotingPower New minimum required voting power a user must have to vote
-     */
-    function setMinRequiredVotingPower(uint256 _minRequiredVotingPower) public onlyOwner trackState {
-        if (_minRequiredVotingPower == 0) revert MustBeGreaterThanZero();
-
-        minRequiredVotingPower = _minRequiredVotingPower;
     }
 
     /**

--- a/src/interfaces/IYieldDistributor.sol
+++ b/src/interfaces/IYieldDistributor.sol
@@ -7,8 +7,6 @@ pragma solidity ^0.8.22;
 interface IYieldDistributor {
     /// @notice The error emitted when attempting to add a project that is already in the `projects` array
     error AlreadyMemberProject();
-    /// @notice The error emitted when a user attempts to vote without the minimum required voting power
-    error BelowMinRequiredVotingPower();
     /// @notice The error emitted when attempting to calculate voting power for a period that has not yet ended
     error EndAfterCurrentBlock();
     /// @notice The error emitted when attempting to vote with a point value greater than `pointsMax`

--- a/test/ButteredBread.t.sol
+++ b/test/ButteredBread.t.sol
@@ -41,8 +41,6 @@ contract ButteredBreadTest is Test {
     uint256 _minHoldingDuration = stdJson.readUint(config_data, "._minHoldingDuration");
     uint256 _lastClaimedBlockNumber = stdJson.readUint(config_data, "._lastClaimedBlockNumber");
     uint256 _yieldFixedSplitDivisor = stdJson.readUint(config_data, "._yieldFixedSplitDivisor");
-    // See test/YieldDistributor.t.sol for explanation of these values
-    uint256 _minRequiredVotingPower = stdJson.readUint(config_data, "._minRequiredVotingPower");
 
     function setUp() public virtual {
         vm.createSelectFork(vm.rpcUrl("gnosis"));
@@ -83,12 +81,12 @@ contract ButteredBreadTest is Test {
             address(GNOSIS_BREAD),
             address(bb),
             _precision,
-            _minRequiredVotingPower,
             _maxPoints,
             _cycleLength,
             _yieldFixedSplitDivisor,
             _lastClaimedBlockNumber,
-            projects1
+            projects1,
+            address(this)
         );
         yieldDistributor = YieldDistributorTestWrapper(
             address(new TransparentUpgradeableProxy(address(yieldDistributorImplementation), address(this), ydinitData))

--- a/test/YieldDistributor.t.sol
+++ b/test/YieldDistributor.t.sol
@@ -54,13 +54,6 @@ contract YieldDistributorTest is Test {
     ButteredBread public butteredBread = ButteredBread(address(_bread));
     uint256 minHoldingDurationInBlocks = _minHoldingDuration / _blocktime;
 
-    // For testing purposes, these values were used in the following way to configure _minRequiredVotingPower
-    // uint256 minHoldingDuration = 10 days;
-    // uint256 blockTime = 5;
-    // uint256 minRequiredVotingPower = (minVotingAmount * minHoldingDuration) / blockTime; // We can assume that blockTime is small enough
-
-    uint256 _minRequiredVotingPower = stdJson.readUint(config_data, "._minRequiredVotingPower");
-
     function setUp() public virtual {
         vm.createSelectFork(vm.rpcUrl("gnosis"));
 
@@ -72,12 +65,12 @@ contract YieldDistributorTest is Test {
             address(bread),
             address(butteredBread),
             _precision,
-            _minRequiredVotingPower,
             _maxPoints,
             _cycleLength,
             _yieldFixedSplitDivisor,
             _lastClaimedBlockNumber,
-            projects1
+            projects1,
+            address(this)
         );
         yieldDistributor = YieldDistributorTestWrapper(
             address(new TransparentUpgradeableProxy(address(yieldDistributorImplementation), address(this), initData))
@@ -92,12 +85,12 @@ contract YieldDistributorTest is Test {
             address(bread),
             address(butteredBread),
             _precision,
-            _minRequiredVotingPower,
             _maxPoints,
             _cycleLength,
             _yieldFixedSplitDivisor,
             _lastClaimedBlockNumber,
-            projects2
+            projects2,
+            address(this)
         );
         yieldDistributor2 = YieldDistributorTestWrapper(
             address(new TransparentUpgradeableProxy(address(yieldDistributorImplementation), address(this), initData))
@@ -111,12 +104,12 @@ contract YieldDistributorTest is Test {
             address(bread),
             address(butteredBread),
             _precision,
-            _minRequiredVotingPower,
             _maxPoints,
             _cycleLength,
             _yieldFixedSplitDivisor,
             _lastClaimedBlockNumber,
-            projects3
+            projects3,
+            address(this)
         );
         yieldDistributorGasKiller = YieldDistributorTestWrapper(
             address(new TransparentUpgradeableProxy(address(yieldDistributorImplementation), address(this), initData))
@@ -454,25 +447,6 @@ contract YieldDistributorTest is Test {
         // Making sure the project was removed
         uint256 length = yieldDistributor.getProjectsLength();
         assertEq(length, 1);
-    }
-
-    function test_castVote_RevertsWhenBelowMinimumVotingPower() public {
-        // Setting up an account without the minimum required voting power
-        address account = address(0x1234567890123356789012345672901234567890);
-
-        vm.roll(START - (minHoldingDurationInBlocks - 1));
-        vm.deal(account, _minVotingAmount);
-        vm.prank(account);
-        bread.mint{value: 5 * 1e4}(account);
-
-        // Setting up for a cycle and casting vote
-        setUpForCycle(yieldDistributor);
-        uint256 vote = 100;
-        percentages.push(vote);
-        vm.prank(account);
-
-        vm.expectRevert(abi.encodeWithSelector(IYieldDistributor.BelowMinRequiredVotingPower.selector));
-        yieldDistributor.castVote(percentages);
     }
 
     // GasKiller Voting System Tests (default voting system)

--- a/test/YieldDistributor.t.sol
+++ b/test/YieldDistributor.t.sol
@@ -627,6 +627,9 @@ contract YieldDistributorTest is Test {
         vm.prank(newVoter);
         yieldDistributor2.castVote(votes2);
 
+        // Manually advance the block number to the next cycle just to be safe
+        vm.roll(START + 1);
+
         // Both voters should be recorded
         assertEq(yieldDistributor2.votersCount(), 2);
         assertEq(yieldDistributor2.voterAtIndex(1), newVoter);

--- a/test/YieldDistributor.t.sol
+++ b/test/YieldDistributor.t.sol
@@ -597,6 +597,51 @@ contract YieldDistributorTest is Test {
         // The votersCount is reset to 0, effectively invalidating the voter list for this cycle
         assertEq(yieldDistributorGasKiller.votersCount(), 0);
     }
+
+    function test_distributeYieldGK_CountsVoteFromUserWhoMintedDuringCycle() public {
+        // Setup: one established voter (has BREAD before cycle) + one new voter (no BREAD at cycle start)
+        address establishedVoter = address(0x1234567890123456789012345678901234567890);
+        address newVoter = address(0xabCDEF1234567890ABcDEF1234567890aBCDeF12);
+        address[] memory accounts = new address[](1);
+        accounts[0] = establishedVoter;
+        setUpAccountsForVoting(accounts);
+
+        // Start the cycle - newVoter has no BREAD or ButteredBread at this point
+        setUpForCycle(yieldDistributor2);
+
+        // Established voter votes 100% to first project
+        uint256[] memory votes1 = new uint256[](2);
+        votes1[0] = 100;
+        votes1[1] = 0;
+        vm.prank(establishedVoter);
+        yieldDistributor2.castVote(votes1);
+
+        // New voter mints BREAD during the current cycle, then votes 100% to second project
+        vm.deal(newVoter, _minVotingAmount);
+        vm.prank(newVoter);
+        bread.mint{value: _minVotingAmount}(newVoter);
+
+        uint256[] memory votes2 = new uint256[](2);
+        votes2[0] = 0;
+        votes2[1] = 100;
+        vm.prank(newVoter);
+        yieldDistributor2.castVote(votes2);
+
+        // Both voters should be recorded
+        assertEq(yieldDistributor2.votersCount(), 2);
+        assertEq(yieldDistributor2.voterAtIndex(1), newVoter);
+
+        // Distribute yield - newVoter's vote should count (getCurrentVotingPower recalculated at distribution time)
+        uint256 yieldAccrued = bread.yieldAccrued();
+        uint256 fixedSplit = yieldAccrued / _yieldFixedSplitDivisor / 2; // half of yield is fixed, split between 2 projects
+
+        yieldDistributor2.distributeYieldGK();
+
+        // secondProject would only get fixed split if newVoter's vote didn't count.
+        // With newVoter's vote, secondProject gets fixed split + voted portion.
+        uint256 secondProjectBalance = bread.balanceOf(secondProject);
+        assertGt(secondProjectBalance, fixedSplit, "newVoter's vote should have counted toward second project");
+    }
 }
 
 contract VotingStreakMultiplierTest is YieldDistributorTest {

--- a/test/test_deploy.json
+++ b/test/test_deploy.json
@@ -19,7 +19,6 @@
     "_cycleLength": 10,
     "_maxPoints": 10000,
     "_lastClaimedBlockNumber": 1,
-    "_minRequiredVotingPower": 10000000000000000000,
     "_minVotingAmount": 10000000000000000000,
     "_minHoldingDuration": 864000,
     "_precision": 1000000000000000000,


### PR DESCRIPTION
## Summary
- Remove `minRequiredVotingPower` state variable and related checks in `castVote` and `castVoteWithMultipliers`
- Remove `BelowMinRequiredVotingPower` error from the interface
- Remove `setMinRequiredVotingPower` admin function
- Add `_initialOwner` parameter to `initialize` function and call `__VotingMultipliers_init` to fix initialization (tests were failing because ownership wasn't set up)
- Update deploy scripts and test configs to remove the deprecated parameter

This allows all BREAD holders to vote regardless of their balance, fixing the issue where `getVotingPower` returns 0 even when users have some voting power but below the minimum threshold.

## Test plan
- [x] All existing tests pass (80 tests)
- [x] Removed test for `BelowMinRequiredVotingPower` revert
- [x] Verified voting works without minimum threshold