### PR TITLE
fix: include current cycle in getCurrentVotingPower

### DIFF
--- a/src/YieldDistributor.sol
+++ b/src/YieldDistributor.sol
@@ -139,8 +139,8 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
      * @return uint256 The voting power of the user
      */
     function getCurrentVotingPower(address _account) public view returns (uint256) {
-        return this.getVotingPowerForPeriod(BREAD, previousCycleStartingBlock, lastClaimedBlockNumber, _account)
-            + this.getVotingPowerForPeriod(BUTTERED_BREAD, previousCycleStartingBlock, lastClaimedBlockNumber, _account);
+        return this.getVotingPowerForPeriod(BREAD, previousCycleStartingBlock, block.number, _account)
+            + this.getVotingPowerForPeriod(BUTTERED_BREAD, previousCycleStartingBlock, block.number, _account);
     }
 
     /// @notice Get the current accumulated voting power for a user


### PR DESCRIPTION
## Summary
- Fixed `getCurrentVotingPower` to include voting power from the current cycle, not just the previous cycle
- Changed the end block parameter from `lastClaimedBlockNumber` to `block.number`

This resolves the issue where users who hold BREAD in the current cycle would see 0 voting power returned.

## Test plan
- [ ] Verify `getCurrentVotingPower` returns non-zero for users with BREAD in current cycle
- [ ] Verify existing voting functionality still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)