### PR TITLE
Short circuit updating projects if there are no updates

### DIFF
--- a/src/YieldDistributor.sol
+++ b/src/YieldDistributor.sol
@@ -400,13 +400,17 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
 
     /**
      * @notice Internal function for updating the project list
+     * @dev Bypasses update if there are no additions or removals queued.
      */
     function _updateBreadchainProjects() internal {
+        if (queuedProjectsForAddition.length == 0 && queuedProjectsForRemoval.length == 0) {
+            // Bypass if nothing to update
+            return;
+        }
+
         for (uint256 i; i < queuedProjectsForAddition.length; ++i) {
             address _project = queuedProjectsForAddition[i];
-
             projects.push(_project);
-
             emit ProjectAdded(_project);
         }
 


### PR DESCRIPTION
Checks that there is at least one queued update to the projects list before running the very storage write heavy function of updating the project list.

FYI, CI has been broken on this repo for a while. If you want to see that this passes tests, you'll need to review https://github.com/BreadchainCoop/breadchain/pull/178 also