### PR TITLE
Add voting cycles for more gas efficient distribution

### DIFF
--- a/src/VotingMultipliers.sol
+++ b/src/VotingMultipliers.sol
@@ -22,6 +22,7 @@ contract VotingMultipliers is Ownable2StepUpgradeable, IVotingMultipliers {
 
     /// @notice Initializes the contract
     /// @param _initialOwner The address of the initial owner
+    /// @custom:oz-upgrades-unsafe-allow missing-initializer-call
     function __VotingMultipliers_init(address _initialOwner) internal onlyInitializing {
         if (owner() == address(0)) {
             __Ownable_init(_initialOwner);

--- a/src/YieldDistributor.sol
+++ b/src/YieldDistributor.sol
@@ -140,10 +140,12 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
 
     /**
      * @notice Initializes the voting cycle
-     * @dev This is required for proxy deployments since storage defaults don't apply
+     * @param _votingCycle The voting cycle number to initialize
      * @custom:oz-upgrades-validate-as-initializer
      */
     function initializeVotingCycle(uint256 _votingCycle) public reinitializer(3) onlyOwner {
+        if (_votingCycle == 0) revert MustBeGreaterThanZero();
+
         if (votingCycle == 0) {
             // Only initialize if voting cycle is not already initialized
             _initializeVotingCycle(_votingCycle);

--- a/src/YieldDistributor.sol
+++ b/src/YieldDistributor.sol
@@ -61,9 +61,9 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
     /// @dev DEPRECATED: Kept for storage layout compatibility. Use `voterAtIndex` and `votersCount` instead.
     address[] public voters;
     /// @notice The mapping of holders to their vote distributions
-    mapping(address => uint256[]) public holderToDistribution;
+    mapping(address => uint256[]) internal _holderToDistribution;
     /// @notice The mapping of holders to their total vote distribution
-    mapping(address => uint256) public holderToDistributionTotal;
+    mapping(address => uint256) internal _holderToDistributionTotal;
     /// @notice The current voting cycle number (incremented each distribution)
     uint256 public votingCycle;
     /// @notice The number of voters in the current cycle
@@ -150,6 +150,28 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
             // Only initialize if voting cycle is not already initialized
             _initializeVotingCycle(_votingCycle);
         }
+    }
+
+    /**
+     * @notice Returns the distribution of voting power for a specific account
+     * @param _account Address of the account to return the distribution for
+     * @return uint256[] The distribution of voting power for the account
+     */
+    function getHolderToDistribution(address _account) public view returns (uint256[] memory) {
+        if (voterVotedCycle[_account] != votingCycle) revert VoterHasNotVotedThisCycle();
+
+        return _holderToDistribution[_account];
+    }
+
+    /**
+     * @notice Returns the total distribution of voting power for a specific account
+     * @param _account Address of the account to return the total distribution for
+     * @return uint256 The total distribution of voting power for the account
+     */
+    function getHolderToDistributionTotal(address _account) public view returns (uint256) {
+        if (voterVotedCycle[_account] != votingCycle) revert VoterHasNotVotedThisCycle();
+
+        return _holderToDistributionTotal[_account];
     }
 
     /**
@@ -373,7 +395,7 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
             voterAtIndex[votersCount++] = _account;
             voterVotedCycle[_account] = votingCycle;
         }
-        holderToDistribution[_account] = _points;
+        _holderToDistribution[_account] = _points;
 
         /// Calculate total points
         uint256 _totalPoints;
@@ -382,7 +404,7 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
             _totalPoints += _points[i];
         }
         if (_totalPoints == 0) revert ZeroVotePoints();
-        holderToDistributionTotal[_account] = _totalPoints;
+        _holderToDistributionTotal[_account] = _totalPoints;
         uint256[] storage _voterDistributions = voterDistributions[_account];
         if (!_hasVotedInCycle) {
             delete voterDistributions[_account];
@@ -427,11 +449,11 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
         for (uint256 i; i < votersCount; ++i) {
             address _voter = voterAtIndex[i];
             uint256 _voterPower = getCurrentVotingPower(_voter);
-            uint256[] memory _voterDistribution = holderToDistribution[_voter];
+            uint256[] memory _voterDistribution = _holderToDistribution[_voter];
             uint256 _vote;
             for (uint256 j; j < projects.length; ++j) {
                 _vote =
-                    (_voterPower * _voterDistribution[j] * PRECISION / holderToDistributionTotal[_voter]) / PRECISION;
+                    (_voterPower * _voterDistribution[j] * PRECISION / _holderToDistributionTotal[_voter]) / PRECISION;
                 _newProjectDistributions[j] += _vote;
                 _totalVotes += _vote;
             }

--- a/src/YieldDistributor.sol
+++ b/src/YieldDistributor.sol
@@ -58,11 +58,20 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
     /// @notice The block number before the last yield distribution
     uint256 public previousCycleStartingBlock;
     /// @notice Array of voters who have cast votes in the current cycle
+    /// @dev DEPRECATED: Kept for storage layout compatibility. Use `voterAtIndex` and `votersCount` instead.
     address[] public voters;
     /// @notice The mapping of holders to their vote distributions
     mapping(address => uint256[]) public holderToDistribution;
     /// @notice The mapping of holders to their total vote distribution
     mapping(address => uint256) public holderToDistributionTotal;
+    /// @notice The current voting cycle number (incremented each distribution)
+    uint256 public votingCycle;
+    /// @notice The number of voters in the current cycle
+    uint256 public votersCount;
+    /// @notice Mapping from index to voter address for current cycle
+    mapping(uint256 => address) public voterAtIndex;
+    /// @notice Mapping from voter address to the cycle they last voted in
+    mapping(address => uint256) public voterVotedCycle;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -105,6 +114,8 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
         for (uint256 i; i < _projects.length; ++i) {
             projects[i] = _projects[i];
         }
+
+        _initializeVotingCycle(1);
     }
 
     /**
@@ -128,12 +139,36 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
     }
 
     /**
+     * @notice Initializes the voting cycle
+     * @dev This is required for proxy deployments since storage defaults don't apply
+     * @custom:oz-upgrades-validate-as-initializer
+     */
+    function initializeVotingCycle(uint256 _votingCycle) public reinitializer(3) onlyOwner {
+        if (votingCycle == 0) {
+            // Only initialize if voting cycle is not already initialized
+            _initializeVotingCycle(_votingCycle);
+        }
+    }
+
+    /**
      * @notice Returns the current distribution of voting power for projects
      * @return address[] The current eligible member projects
      * @return uint256[] The current distribution of voting power for projects
      */
     function getCurrentVotingDistribution() public view returns (address[] memory, uint256[] memory) {
         return (projects, projectDistributions);
+    }
+
+    /**
+     * @notice Returns the list of voters in the current cycle
+     * @return address[] Array of voter addresses who have voted in the current cycle
+     */
+    function getCurrentCycleVoters() public view returns (address[] memory) {
+        address[] memory _voters = new address[](votersCount);
+        for (uint256 i; i < votersCount; ++i) {
+            _voters[i] = voterAtIndex[i];
+        }
+        return _voters;
     }
 
     /**
@@ -263,8 +298,10 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
         _updateBreadchainProjects();
         emit YieldDistributed(balance, totalVotes, distributions);
 
-        delete voters;
-        delete currentVotes;
+        // Gas-efficient reset: increment cycle and reset counter instead of deleting arrays
+        votingCycle++;
+        votersCount = 0;
+        currentVotes = 0;
         projectDistributions = new uint256[](projects.length);
     }
 
@@ -326,11 +363,13 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
         uint256 _projectsLength = projects.length;
         if (_points.length != _projectsLength) revert IncorrectNumberOfProjects();
 
-        /// Add voter to list if they have not voted yet
-        if (holderToDistribution[_account].length > 0) {
-            delete holderToDistribution[_account];
-        } else {
-            voters.push(_account);
+        /// Check if voter has voted in current cycle using cycle counter
+        bool _hasVotedInCycle = voterVotedCycle[_account] == votingCycle;
+
+        /// Add voter to list if they have not voted this cycle
+        if (!_hasVotedInCycle) {
+            voterAtIndex[votersCount++] = _account;
+            voterVotedCycle[_account] = votingCycle;
         }
         holderToDistribution[_account] = _points;
 
@@ -342,8 +381,6 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
         }
         if (_totalPoints == 0) revert ZeroVotePoints();
         holderToDistributionTotal[_account] = _totalPoints;
-
-        bool _hasVotedInCycle = accountLastVoted[_account] > lastClaimedBlockNumber;
         uint256[] storage _voterDistributions = voterDistributions[_account];
         if (!_hasVotedInCycle) {
             delete voterDistributions[_account];
@@ -385,8 +422,8 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
     {
         _newProjectDistributions = new uint256[](projects.length);
 
-        for (uint256 i; i < voters.length; ++i) {
-            address _voter = voters[i];
+        for (uint256 i; i < votersCount; ++i) {
+            address _voter = voterAtIndex[i];
             uint256 _voterPower = getCurrentVotingPower(_voter);
             uint256[] memory _voterDistribution = holderToDistribution[_voter];
             uint256 _vote;
@@ -396,8 +433,6 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
                 _newProjectDistributions[j] += _vote;
                 _totalVotes += _vote;
             }
-            delete holderToDistribution[_voter];
-            delete holderToDistributionTotal[_voter];
         }
     }
 
@@ -439,6 +474,18 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
 
         delete queuedProjectsForAddition;
         delete queuedProjectsForRemoval;
+    }
+
+    /**
+     * @notice Internal function to initialize the voting cycle
+     * @dev Initialize voting cycle to 1 so that uninitialized voterVotedCycle mappings (default 0)
+     * @dev are correctly identified as "not voted in current cycle"
+     */
+    function _initializeVotingCycle(uint256 _votingCycle) internal {
+        votingCycle = _votingCycle;
+
+        // Reset deprecated `voters` array
+        delete voters;
     }
 
     /**

--- a/src/YieldDistributor.sol
+++ b/src/YieldDistributor.sol
@@ -507,11 +507,16 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
 
     /**
      * @notice Internal function to initialize the voting cycle
-     * @dev Initialize voting cycle to 1 so that uninitialized voterVotedCycle mappings (default 0)
-     * @dev are correctly identified as "not voted in current cycle"
+     * @dev Initialize voting cycle so that uninitialized voterVotedCycle mappings (default 0)
+     * @dev are correctly identified as "not voted in current cycle".
+     * @dev Resets all in-progress vote state (currentVotes, projectDistributions, votersCount)
+     * @dev to prevent double-counting if called mid-cycle during an upgrade.
      */
     function _initializeVotingCycle(uint256 _votingCycle) internal {
         votingCycle = _votingCycle;
+        votersCount = 0;
+        currentVotes = 0;
+        projectDistributions = new uint256[](projects.length);
     }
 
     /**

--- a/src/YieldDistributor.sol
+++ b/src/YieldDistributor.sol
@@ -59,7 +59,7 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
     uint256 public previousCycleStartingBlock;
     /// @notice Array of voters who have cast votes in the current cycle
     /// @dev DEPRECATED: Kept for storage layout compatibility. Use `voterAtIndex` and `votersCount` instead.
-    address[] public voters;
+    address[] internal _deprecated_voters;
     /// @notice The mapping of holders to their vote distributions
     mapping(address => uint256[]) internal _holderToDistribution;
     /// @notice The mapping of holders to their total vote distribution
@@ -78,6 +78,7 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
         _disableInitializers();
     }
 
+    /// @custom:oz-upgrades-unsafe-allow missing-initializer-call
     function initialize(
         address _bread,
         address _butteredBread,
@@ -122,6 +123,8 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
      * @notice Initializes the VotingMultipliers contract
      * @param _initialOwner The address of the initial owner
      * @custom:oz-upgrades-validate-as-initializer
+     * @custom:oz-upgrades-unsafe-allow missing-initializer-call
+     * @custom:oz-upgrades-unsafe-allow incorrect-initializer-order
      */
     function initializeVotingMultipliers(address _initialOwner) public reinitializer(1) {
         __VotingMultipliers_init(_initialOwner);
@@ -132,6 +135,7 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
      * @param _avsAddress The address of the AVS service manager
      * @param _blsSignatureChecker The address of the BLS signature checker
      * @custom:oz-upgrades-validate-as-initializer
+     * @custom:oz-upgrades-unsafe-allow missing-initializer-call
      */
     function initializeGasKiller(address _avsAddress, address _blsSignatureChecker) public reinitializer(2) onlyOwner {
         _setAvsAddress(_avsAddress);
@@ -142,6 +146,7 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
      * @notice Initializes the voting cycle
      * @param _votingCycle The voting cycle number to initialize
      * @custom:oz-upgrades-validate-as-initializer
+     * @custom:oz-upgrades-unsafe-allow missing-initializer-call
      */
     function initializeVotingCycle(uint256 _votingCycle) public reinitializer(3) onlyOwner {
         if (_votingCycle == 0) revert MustBeGreaterThanZero();
@@ -507,9 +512,6 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
      */
     function _initializeVotingCycle(uint256 _votingCycle) internal {
         votingCycle = _votingCycle;
-
-        // Reset deprecated `voters` array
-        delete voters;
     }
 
     /**

--- a/src/interfaces/IYieldDistributor.sol
+++ b/src/interfaces/IYieldDistributor.sol
@@ -23,12 +23,14 @@ interface IYieldDistributor {
     error ProjectNotFound();
     /// @notice The error emitted when attempting to calculate voting power for a period with a start block greater than the end block
     error StartMustBeBeforeEnd();
+    /// @notice The error emitted when a transfer fails
+    error TransferFailed();
+    /// @notice The error emitted when a voter has not voted this cycle
+    error VoterHasNotVotedThisCycle();
     /// @notice The error emitted when attempting to distribute yield when access conditions are not met
     error YieldNotResolved();
     /// @notice The error emitted if a user with zero points attempts to cast votes
     error ZeroVotePoints();
-    /// @notice The error emitted when a transfer fails
-    error TransferFailed();
 
     /// @notice The event emitted when an account casts a vote
     event BreadHolderVoted(address indexed account, uint256[] points, address[] projects);

--- a/test/YieldDistributor.t.sol
+++ b/test/YieldDistributor.t.sol
@@ -625,9 +625,6 @@ contract YieldDistributorTest is Test {
         // Check that voter count is reset after distribution (gas-efficient approach)
         // The votersCount is reset to 0, effectively invalidating the voter list for this cycle
         assertEq(yieldDistributorGasKiller.votersCount(), 0);
-
-        // Note: holderToDistributionTotal values persist for gas efficiency but are not used
-        // once the cycle advances, as voters must cast new votes each cycle
     }
 }
 

--- a/test/YieldDistributor.t.sol
+++ b/test/YieldDistributor.t.sol
@@ -609,10 +609,11 @@ contract YieldDistributorTest is Test {
         vm.prank(accounts[2]);
         yieldDistributorGasKiller.castVote(votes3);
 
-        // Check that all voters are recorded
-        assertEq(yieldDistributorGasKiller.voters(0), accounts[0]);
-        assertEq(yieldDistributorGasKiller.voters(1), accounts[1]);
-        assertEq(yieldDistributorGasKiller.voters(2), accounts[2]);
+        // Check that all voters are recorded using new cycle-based tracking
+        assertEq(yieldDistributorGasKiller.votersCount(), 3);
+        assertEq(yieldDistributorGasKiller.voterAtIndex(0), accounts[0]);
+        assertEq(yieldDistributorGasKiller.voterAtIndex(1), accounts[1]);
+        assertEq(yieldDistributorGasKiller.voterAtIndex(2), accounts[2]);
         // Check that vote data is recorded correctly
         assertEq(yieldDistributorGasKiller.holderToDistributionTotal(accounts[0]), 100);
         assertEq(yieldDistributorGasKiller.holderToDistributionTotal(accounts[1]), 50);
@@ -621,15 +622,12 @@ contract YieldDistributorTest is Test {
         // Distribute yield using GasKiller method
         yieldDistributorGasKiller.distributeYieldGK();
 
-        // Check that voters array is cleared after distribution
-        vm.expectRevert();
-        yieldDistributorGasKiller.voters(0);
+        // Check that voter count is reset after distribution (gas-efficient approach)
+        // The votersCount is reset to 0, effectively invalidating the voter list for this cycle
+        assertEq(yieldDistributorGasKiller.votersCount(), 0);
 
-        // Check that vote data is cleared after distribution
-        // After distribution, all totals should be reset to 0
-        assertEq(yieldDistributorGasKiller.holderToDistributionTotal(accounts[0]), 0);
-        assertEq(yieldDistributorGasKiller.holderToDistributionTotal(accounts[1]), 0);
-        assertEq(yieldDistributorGasKiller.holderToDistributionTotal(accounts[2]), 0);
+        // Note: holderToDistributionTotal values persist for gas efficiency but are not used
+        // once the cycle advances, as voters must cast new votes each cycle
     }
 }
 

--- a/test/YieldDistributor.t.sol
+++ b/test/YieldDistributor.t.sol
@@ -615,9 +615,9 @@ contract YieldDistributorTest is Test {
         assertEq(yieldDistributorGasKiller.voterAtIndex(1), accounts[1]);
         assertEq(yieldDistributorGasKiller.voterAtIndex(2), accounts[2]);
         // Check that vote data is recorded correctly
-        assertEq(yieldDistributorGasKiller.holderToDistributionTotal(accounts[0]), 100);
-        assertEq(yieldDistributorGasKiller.holderToDistributionTotal(accounts[1]), 50);
-        assertEq(yieldDistributorGasKiller.holderToDistributionTotal(accounts[2]), 25);
+        assertEq(yieldDistributorGasKiller.getHolderToDistributionTotal(accounts[0]), 100);
+        assertEq(yieldDistributorGasKiller.getHolderToDistributionTotal(accounts[1]), 50);
+        assertEq(yieldDistributorGasKiller.getHolderToDistributionTotal(accounts[2]), 25);
 
         // Distribute yield using GasKiller method
         yieldDistributorGasKiller.distributeYieldGK();


### PR DESCRIPTION
The ultimate goal of these changes is to optimize the distribution functions so that less gas is spent on "unoptimizable" operations (in context of gas savings from Gas Killer). The key optimizations here are:

- remove `delete holderToDistribution[_voter];` in "_commitVotedDistribution()" used by "distributeYieldGK()"
- remove `delete holderToDistributionTotal[_voter];` in "_commitVotedDistribution()" used by "distributeYieldGK()"
- remove `delete voters;` in "_executeAndFinalizeDistribution()" used by both distribution functions

These are eliminated by a redesign where we track a voting cycle index. When voters vote, we set their voting cycle index to the current one and update a couple of mappings instead of pushing them onto an array. This way we can just increment the cycle index and reset the voter count.

NOTE: I'm not sure exactly how the frontend makes use of the "voters" variable. It may be the case that we need to update some frontend code.

