### PR TITLE
fix: fee-on-transfer token accounting in ButteredBread deposit

### DIFF
--- a/src/ButteredBread.sol
+++ b/src/ButteredBread.sol
@@ -143,8 +143,12 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, Ownable2StepUpg
 
     /// @notice Deposit LP tokens and mint ButteredBread with corresponding LP scaling factor
     function _deposit(address _account, address _lp, uint256 _amount) internal {
+        uint256 balanceBefore = IERC20(_lp).balanceOf(address(this));
         bool success = IERC20(_lp).transferFrom(_account, address(this), _amount);
         if (!success) revert TransferFailed();
+
+        uint256 actualReceived = IERC20(_lp).balanceOf(address(this));
+        _amount = actualReceived - balanceBefore;
 
         _syncDelegation(_account);
 

--- a/src/test/FeeOnTransferERC20.sol
+++ b/src/test/FeeOnTransferERC20.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.25;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @notice Mock ERC20 that deducts a percentage fee on every transfer (fee is burned)
+contract FeeOnTransferERC20 is ERC20 {
+    uint256 public feePercent;
+
+    constructor(uint256 _feePercent) ERC20("FeeOnTransfer", "FOT") {
+        feePercent = _feePercent;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        if (from != address(0) && to != address(0)) {
+            uint256 fee = value * feePercent / 100;
+            // Transfer (value - fee) to recipient, then burn the fee from sender
+            super._update(from, to, value - fee);
+            super._update(from, address(0), fee);
+        } else {
+            super._update(from, to, value);
+        }
+    }
+}

--- a/test/ButteredBread.t.sol
+++ b/test/ButteredBread.t.sol
@@ -17,6 +17,7 @@ import {ICurveStableSwap} from "src/interfaces/ICurveStableSwap.sol";
 import {IERC20Votes} from "src/interfaces/IERC20Votes.sol";
 import {YieldDistributorTestWrapper} from "src/test/YieldDistributorTestWrapper.sol";
 import {YieldDistributor, IYieldDistributor} from "src/YieldDistributor.sol";
+import {FeeOnTransferERC20} from "src/test/FeeOnTransferERC20.sol";
 
 uint256 constant XDAI_FACTOR = 700; // 700% scaling factor; 7X
 uint256 constant TOKEN_AMOUNT = 1000 ether;
@@ -293,7 +294,7 @@ contract ButteredBreadTest_Unit is ButteredBreadTest {
     function testModifyScalingFactorEmitsEvent() public {
         address lp = GNOSIS_CURVE_POOL_XDAI_BREAD;
         uint256 oldFactor = bb.scalingFactors(lp);
-        uint256 newFactor = oldFactor + 50;   
+        uint256 newFactor = oldFactor + 50;
 
         vm.expectEmit(true, false, false, true);
         emit IButteredBread.ScalingFactorModified(lp, oldFactor, newFactor);
@@ -576,5 +577,153 @@ contract ButteredBreadTest_Integration is ButteredBreadTest {
         uint256 bbBalance = bb.balanceOf(ALICE);
         uint256 bBalance = IERC20(GNOSIS_BREAD).balanceOf(ALICE);
         assertEq(yieldDistributor.getCurrentVotingPower(ALICE), bbBalance + bBalance);
+    }
+}
+
+/// @notice Tests for issue #187: fee-on-transfer token accounting
+contract ButteredBreadTest_FeeOnTransfer is ButteredBreadTest {
+    FeeOnTransferERC20 public fotToken;
+    uint256 public constant FEE_PERCENT = 5;
+    uint256 public constant FOT_FACTOR = 200; // 2X scaling
+
+    function setUp() public virtual override {
+        super.setUp();
+        fotToken = new FeeOnTransferERC20(FEE_PERCENT);
+
+        // Allowlist the fee-on-transfer token
+        address[] memory emptyList = new address[](0);
+        bb.modifyScalingFactor(address(fotToken), FOT_FACTOR, emptyList);
+        bb.modifyAllowList(address(fotToken), true);
+    }
+
+    /// @dev Helper to mint FOT tokens and approve ButteredBread
+    function _setupFotDepositor(address _account, uint256 _amount) internal {
+        fotToken.mint(_account, _amount);
+        vm.prank(_account);
+        fotToken.approve(address(bb), _amount);
+    }
+
+    /// @notice Deposit should record actual received amount, not requested amount
+    function testDepositAccountsForTransferFee() public {
+        uint256 depositAmount = 1000 ether;
+        uint256 expectedReceived = depositAmount - (depositAmount * FEE_PERCENT / 100); // 950 ether
+
+        _setupFotDepositor(ALICE, depositAmount);
+
+        vm.prank(ALICE);
+        bb.deposit(address(fotToken), depositAmount);
+
+        // Internal balance should reflect actual tokens received, not requested amount
+        uint256 recordedBalance = bb.accountToLPBalance(ALICE, address(fotToken));
+        assertEq(recordedBalance, expectedReceived, "Recorded balance should equal actual received amount");
+
+        // Contract's token balance should match recorded balance
+        uint256 contractBalance = fotToken.balanceOf(address(bb));
+        assertEq(contractBalance, expectedReceived, "Contract token balance should match recorded balance");
+
+        // ButteredBread minted should be based on actual received amount
+        uint256 expectedBB = expectedReceived * FOT_FACTOR / fixedPointPercent;
+        assertEq(bb.balanceOf(ALICE), expectedBB, "BB minted should be based on actual received amount");
+    }
+
+    /// @notice Multiple depositors should not allow early withdrawers to drain the contract
+    function testFeeOnTransferNoDrain() public {
+        uint256 aliceDeposit = 1000 ether;
+        uint256 bobbyDeposit = 1000 ether;
+        uint256 aliceReceived = aliceDeposit - (aliceDeposit * FEE_PERCENT / 100); // 950
+        uint256 bobbyReceived = bobbyDeposit - (bobbyDeposit * FEE_PERCENT / 100); // 950
+
+        _setupFotDepositor(ALICE, aliceDeposit);
+        _setupFotDepositor(BOBBY, bobbyDeposit);
+
+        vm.prank(ALICE);
+        bb.deposit(address(fotToken), aliceDeposit);
+
+        vm.prank(BOBBY);
+        bb.deposit(address(fotToken), bobbyDeposit);
+
+        // Contract should hold exactly what was actually received
+        assertEq(
+            fotToken.balanceOf(address(bb)),
+            aliceReceived + bobbyReceived,
+            "Contract should hold sum of actual received amounts"
+        );
+
+        // Alice withdraws her full recorded balance
+        uint256 aliceRecorded = bb.accountToLPBalance(ALICE, address(fotToken));
+        vm.prank(ALICE);
+        bb.withdraw(address(fotToken), aliceRecorded);
+
+        // Contract should still hold enough for Bobby's withdrawal
+        uint256 contractRemaining = fotToken.balanceOf(address(bb));
+        uint256 bobbyRecorded = bb.accountToLPBalance(BOBBY, address(fotToken));
+        assertGe(
+            contractRemaining, bobbyRecorded, "Contract must hold enough tokens for remaining depositors to withdraw"
+        );
+
+        // Bobby should be able to withdraw without reverting
+        vm.prank(BOBBY);
+        bb.withdraw(address(fotToken), bobbyRecorded);
+
+        assertEq(bb.accountToLPBalance(BOBBY, address(fotToken)), 0, "Bobby should have zero balance after withdrawal");
+    }
+
+    /// @notice Voting power (BB balance) should not be inflated beyond actual deposits
+    function testFeeOnTransferVotingPowerNotInflated() public {
+        uint256 depositAmount = 1000 ether;
+        uint256 expectedReceived = depositAmount - (depositAmount * FEE_PERCENT / 100);
+
+        _setupFotDepositor(ALICE, depositAmount);
+
+        vm.prank(ALICE);
+        bb.deposit(address(fotToken), depositAmount);
+
+        // BB balance should be based on actual received, not the inflated requested amount
+        uint256 inflatedBB = depositAmount * FOT_FACTOR / fixedPointPercent;
+        uint256 correctBB = expectedReceived * FOT_FACTOR / fixedPointPercent;
+
+        assertEq(bb.balanceOf(ALICE), correctBB, "BB should reflect actual deposit");
+        assertLt(bb.balanceOf(ALICE), inflatedBB, "BB must be less than inflated amount");
+    }
+
+    /// @notice ButterAdded event should emit the actual received amount
+    function testFeeOnTransferEventEmitsActualAmount() public {
+        uint256 depositAmount = 1000 ether;
+        uint256 expectedReceived = depositAmount - (depositAmount * FEE_PERCENT / 100);
+
+        _setupFotDepositor(ALICE, depositAmount);
+
+        vm.expectEmit(true, true, false, true);
+        emit IButteredBread.ButterAdded(ALICE, address(fotToken), expectedReceived);
+
+        vm.prank(ALICE);
+        bb.deposit(address(fotToken), depositAmount);
+    }
+
+    /// @notice Fuzz test: deposit accounting holds for any fee percentage and amount
+    function testFeeOnTransferDepositFuzz(uint256 _depositAmount, uint256 _feePercent) public {
+        _feePercent = bound(_feePercent, 1, 50); // 1% to 50% fee
+        _depositAmount = bound(_depositAmount, 1 ether, 100_000 ether);
+
+        FeeOnTransferERC20 fuzzToken = new FeeOnTransferERC20(_feePercent);
+
+        address[] memory emptyList = new address[](0);
+        bb.modifyScalingFactor(address(fuzzToken), FOT_FACTOR, emptyList);
+        bb.modifyAllowList(address(fuzzToken), true);
+
+        fuzzToken.mint(ALICE, _depositAmount);
+        vm.prank(ALICE);
+        fuzzToken.approve(address(bb), _depositAmount);
+
+        vm.prank(ALICE);
+        bb.deposit(address(fuzzToken), _depositAmount);
+
+        uint256 expectedReceived = _depositAmount - (_depositAmount * _feePercent / 100);
+        uint256 contractBalance = fuzzToken.balanceOf(address(bb));
+        uint256 recordedBalance = bb.accountToLPBalance(ALICE, address(fuzzToken));
+
+        assertEq(recordedBalance, expectedReceived, "Recorded balance must match actual received");
+        assertEq(contractBalance, expectedReceived, "Contract balance must match actual received");
+        assertEq(recordedBalance, contractBalance, "Recorded and contract balances must be in sync");
     }
 }


### PR DESCRIPTION
## Summary
- Adds balance-before/balance-after pattern in `_deposit()` to record actual tokens received instead of the requested amount, preventing inflated accounting with fee-on-transfer LP tokens
- Adds `FeeOnTransferERC20` mock and 5 tests (including fuzz) covering deposit accounting, drain prevention, voting power accuracy, and event correctness

Closes #187

## Test plan
- [x] `testDepositAccountsForTransferFee` — recorded balance and ButteredBread minted reflect actual received amount
- [x] `testFeeOnTransferNoDrain` — early withdrawer cannot drain late depositor's funds
- [x] `testFeeOnTransferVotingPowerNotInflated` — ButteredBread (voting power) is not inflated beyond actual deposit
- [x] `testFeeOnTransferEventEmitsActualAmount` — `ButterAdded` event emits actual received amount
- [x] `testFeeOnTransferDepositFuzz` — accounting holds across fee percentages (1-50%) and deposit amounts