### PR TITLE
Set default 'lastClaimedBlockNumber' to current block

### DIFF
--- a/script/deploy/DeployYieldDistributor.s.sol
+++ b/script/deploy/DeployYieldDistributor.s.sol
@@ -19,22 +19,27 @@ contract DeployYieldDistributor is Script {
     uint256 _lastClaimedBlockNumber = stdJson.readUint(config_data, "._lastClaimedBlockNumber");
     uint256 _yieldFixedSplitDivisor = stdJson.readUint(config_data, "._yieldFixedSplitDivisor");
     address _owner = stdJson.readAddress(config_data, "._owner");
-    bytes projectsRaw = stdJson.parseRaw(config_data, "._projects");
-    address[] projects = abi.decode(projectsRaw, (address[]));
-    bytes initData = abi.encodeWithSelector(
-        YieldDistributor.initialize.selector,
-        _bread,
-        _butteredBread,
-        _precision,
-        _maxPoints,
-        _cycleLength,
-        _yieldFixedSplitDivisor,
-        _lastClaimedBlockNumber,
-        projects,
-        _owner
-    );
+    address[] _projects = abi.decode(stdJson.parseRaw(config_data, "._projects"), (address[]));
 
     function run() external {
+        uint256 lastClaimedBlockNumber = _lastClaimedBlockNumber == 0 ? block.number : _lastClaimedBlockNumber;
+        if (_lastClaimedBlockNumber == 0) {
+            console2.log("Using current block as lastClaimedBlockNumber:", lastClaimedBlockNumber);
+        }
+
+        bytes memory initData = abi.encodeWithSelector(
+            YieldDistributor.initialize.selector,
+            _bread,
+            _butteredBread,
+            _precision,
+            _maxPoints,
+            _cycleLength,
+            _yieldFixedSplitDivisor,
+            lastClaimedBlockNumber,
+            _projects,
+            _owner
+        );
+
         vm.startBroadcast();
         YieldDistributor yieldDistributorImplementation = new YieldDistributor();
         YieldDistributor yieldDistributor = YieldDistributor(

--- a/script/deploy/DeployYieldDistributor.s.sol
+++ b/script/deploy/DeployYieldDistributor.s.sol
@@ -13,20 +13,15 @@ contract DeployYieldDistributor is Script {
     string config_data = vm.readFile(deployConfigPath);
     address _bread = stdJson.readAddress(config_data, "._bread");
     address _butteredBread = stdJson.readAddress(config_data, "._butteredBread");
-    uint256 _cycleLength = stdJson.readUint(config_data, "._cycleLength");
-    uint256 _maxPoints = stdJson.readUint(config_data, "._maxPoints");
     uint256 _precision = stdJson.readUint(config_data, "._precision");
-    uint256 _lastClaimedBlockNumber = stdJson.readUint(config_data, "._lastClaimedBlockNumber");
+    uint256 _maxPoints = stdJson.readUint(config_data, "._maxPoints");
+    uint256 _cycleLength = stdJson.readUint(config_data, "._cycleLength");
     uint256 _yieldFixedSplitDivisor = stdJson.readUint(config_data, "._yieldFixedSplitDivisor");
-    address _owner = stdJson.readAddress(config_data, "._owner");
+    uint256 _lastClaimedBlockNumber = stdJson.readUint(config_data, "._lastClaimedBlockNumber");
     address[] _projects = abi.decode(stdJson.parseRaw(config_data, "._projects"), (address[]));
+    address _owner = stdJson.readAddress(config_data, "._owner");
 
     function run() external {
-        uint256 lastClaimedBlockNumber = _lastClaimedBlockNumber == 0 ? block.number : _lastClaimedBlockNumber;
-        if (_lastClaimedBlockNumber == 0) {
-            console2.log("Using current block as lastClaimedBlockNumber:", lastClaimedBlockNumber);
-        }
-
         bytes memory initData = abi.encodeWithSelector(
             YieldDistributor.initialize.selector,
             _bread,
@@ -35,7 +30,7 @@ contract DeployYieldDistributor is Script {
             _maxPoints,
             _cycleLength,
             _yieldFixedSplitDivisor,
-            lastClaimedBlockNumber,
+            _lastClaimedBlockNumber,
             _projects,
             _owner
         );

--- a/script/deploy/config/deployYD.json
+++ b/script/deploy/config/deployYD.json
@@ -1,6 +1,6 @@
 {
     "_bread": "0xa555d5344f6FB6c65da19e403Cb4c1eC4a1a5Ee3",
-    "_butteredBread": "0x123456789abcdef123456789abcdef123456789a",
+    "_butteredBread": "0x680B581605DC0A6902735a80dE35Cb0Ef6E90865",
     "_owner": "0x918dEf5d593F46735f74F9E2B280Fe51AF3A99ad",
     "_projectNames": [
         "laborDao",
@@ -19,7 +19,7 @@
     "_blocktime": 5,
     "_maxPoints": 10000,
     "_cycleLength": 518400,
-    "_lastClaimedBlockNumber": 1,
+    "_lastClaimedBlockNumber": 0,
     "_precision": 1000000000000000000,
     "_yieldFixedSplitDivisor": 2
 }

--- a/src/YieldDistributor.sol
+++ b/src/YieldDistributor.sol
@@ -97,10 +97,15 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
     ) public initializer {
         if (
             _bread == address(0) || _butteredBread == address(0) || _precision == 0 || _maxPoints == 0
-                || _cycleLength == 0 || _yieldFixedSplitDivisor == 0 || _lastClaimedBlockNumber == 0
-                || _projects.length == 0 || _initialOwner == address(0)
+                || _cycleLength == 0 || _yieldFixedSplitDivisor == 0 || _projects.length == 0
+                || _initialOwner == address(0)
         ) {
             revert MustBeGreaterThanZero();
+        }
+
+        // If the last claimed block number is not set, use the current block number
+        if (_lastClaimedBlockNumber == 0) {
+            _lastClaimedBlockNumber = block.number;
         }
 
         __Ownable_init(_initialOwner);


### PR DESCRIPTION
In the deploy scripts, allow for setting the value 0 for `lastClaimedBlockNumber` so it will default to the current block (or close). This makes sure new deployments are starting their cycle at/near the block they are deployed at. It's imprecise, because the contract deployment might actually clear a block or two later, but we avoiding adding it as contract logic so we don't bloat the initializer.

This PR also updates the config json to include the real ButteredBread contract address instead of the placeholder.