### PR TITLE
Add gasKillerManager role for GasKiller configuration

### DIFF
--- a/src/YieldDistributor.sol
+++ b/src/YieldDistributor.sol
@@ -77,6 +77,14 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
     mapping(uint256 => address) public voterAtIndex;
     /// @notice Mapping from voter address to the cycle they last voted in
     mapping(address => uint256) public voterVotedCycle;
+    /// @notice The address authorized to manage GasKiller settings (AVS, BLS, block stale measure)
+    address public gasKillerManager;
+
+    /// @notice Restricts access to the GasKiller manager or the owner
+    modifier onlyGasKillerManager() {
+        if (msg.sender != gasKillerManager && msg.sender != owner()) revert NotGasKillerManager();
+        _;
+    }
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -607,27 +615,35 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
     }
 
     /**
-     * @notice Allows the owner to set the AVS address
+     * @notice Set the address authorized to manage GasKiller settings
+     * @param _gasKillerManager The new GasKiller manager address
+     */
+    function setGasKillerManager(address _gasKillerManager) public onlyOwner trackState {
+        gasKillerManager = _gasKillerManager;
+    }
+
+    /**
+     * @notice Allows the GasKiller manager or owner to set the AVS address
      * @param newAvsAddress The new AVS address
      * @dev Also updates the namespace for the contract
      */
-    function setAvsAddress(address newAvsAddress) external onlyOwner trackState {
+    function setAvsAddress(address newAvsAddress) external onlyGasKillerManager trackState {
         _setAvsAddress(newAvsAddress);
     }
 
     /**
-     * @notice Allows the owner to set the BLS signature checker address
+     * @notice Allows the GasKiller manager or owner to set the BLS signature checker address
      * @param newBlsSignatureChecker The new BLS signature checker address
      */
-    function setBlsSignatureChecker(address newBlsSignatureChecker) external onlyOwner trackState {
+    function setBlsSignatureChecker(address newBlsSignatureChecker) external onlyGasKillerManager trackState {
         _setBlsSignatureChecker(newBlsSignatureChecker);
     }
 
     /**
-     * @notice Allows the owner to set the block stale measure
+     * @notice Allows the GasKiller manager or owner to set the block stale measure
      * @param _blockStaleMeasure The new block stale measure
      */
-    function setBlockStaleMeasure(uint256 _blockStaleMeasure) external onlyOwner trackState {
+    function setBlockStaleMeasure(uint256 _blockStaleMeasure) external onlyGasKillerManager trackState {
         _setBlockStaleMeasure(_blockStaleMeasure);
     }
 }

--- a/src/interfaces/IYieldDistributor.sol
+++ b/src/interfaces/IYieldDistributor.sol
@@ -29,6 +29,8 @@ interface IYieldDistributor {
     error YieldNotResolved();
     /// @notice The error emitted if a user with zero points attempts to cast votes
     error ZeroVotePoints();
+    /// @notice The error emitted when a caller is not the GasKiller manager or owner
+    error NotGasKillerManager();
 
     /// @notice The event emitted when an account casts a vote
     event BreadHolderVoted(address indexed account, uint256[] points, address[] projects);


### PR DESCRIPTION
## Summary

Add a dedicated `gasKillerManager` role that can call `setAvsAddress`, `setBlsSignatureChecker`, and `setBlockStaleMeasure`. The contract owner retains the ability to call these functions directly and can delegate GasKiller configuration by setting the manager address.

## Changes

- Add `gasKillerManager` storage variable
- Add `onlyGasKillerManager` modifier allowing either the manager or owner
- Add `setGasKillerManager()` function for owner to assign the manager role
- Update three GasKiller setter functions to use the new access control

## Test plan

- Verify owner can still call the three setter functions
- Verify gasKillerManager can call the three setter functions
- Verify non-manager non-owner addresses are rejected