### PR TITLE
fix: prevent streak multiplier from being maxed in one cycle

### DIFF
--- a/src/multipliers/VotingStreakMultiplier.sol
+++ b/src/multipliers/VotingStreakMultiplier.sol
@@ -29,6 +29,10 @@ contract VotingStreakMultiplier is Initializable, OwnableUpgradeable, IMultiplie
     /// @notice Mapping of user addresses to their multiplier validity period
     mapping(address => uint256) public userToValidUntil;
 
+    /// @notice Mapping of user addresses to the lastClaimedBlockNumber when their streak was last incremented
+    /// @dev Prevents streak from being incremented more than once per cycle (issue #185)
+    mapping(address => uint256) public userLastUpdatedCycle;
+
     /// @notice Error emitted when an invalid multiplier increment is provided
     error InvalidMultiplierIncrement();
 
@@ -94,6 +98,14 @@ contract VotingStreakMultiplier is Initializable, OwnableUpgradeable, IMultiplie
             return;
         }
 
+        // Prevent streak from being incremented more than once per cycle (issue #185)
+        // Without this check, a user could call updateMultiplyingFactor (or castVoteWithMultipliers)
+        // multiple times before their first vote to max the streak in a single cycle.
+        // Use lastClaimedBlock as the cycle identifier since it changes each distribution.
+        if (userLastUpdatedCycle[_user] == lastClaimedBlock) {
+            return;
+        }
+
         uint256 currentMultiplier = getMultiplyingFactor(_user);
         uint256 newMultiplier = (currentMultiplier == MultiplierConstants.BASE_MULTIPLIER)
             ? MultiplierConstants.BASE_MULTIPLIER + multiplierIncrement
@@ -102,6 +114,7 @@ contract VotingStreakMultiplier is Initializable, OwnableUpgradeable, IMultiplie
                 (MultiplierConstants.BASE_MULTIPLIER + (maxMultiplierIncrements * multiplierIncrement))
             );
 
+        userLastUpdatedCycle[_user] = lastClaimedBlock;
         userToMultiplier[_user] = newMultiplier;
         userToValidUntil[_user] = lastClaimedBlock + (2 * cycleLength);
         emit MultiplierUpdated(_user, newMultiplier, userToValidUntil[_user]);

--- a/test/YieldDistributor.t.sol
+++ b/test/YieldDistributor.t.sol
@@ -813,6 +813,26 @@ contract VotingStreakMultiplierTest is YieldDistributorTest {
         assertEq(multiplier.getMultiplyingFactor(testAccount), baseMultiplier + multiplier.multiplierIncrement());
     }
 
+    function test_updateMultiplyingFactor_oncePerCycle() public {
+        VotingStreakMultiplier multiplier = setUpVotingStreakMultiplier();
+        address testAccount = setUpTestAccount();
+        uint256 baseMultiplier = 1e18;
+        setUpForCycle(yieldDistributor, 0);
+
+        // Initial multiplier should be base
+        assertEq(multiplier.getMultiplyingFactor(testAccount), baseMultiplier);
+
+        // First call to updateMultiplyingFactor should increment
+        multiplier.updateMultiplyingFactor(testAccount);
+        uint256 afterFirst = multiplier.userToMultiplier(testAccount);
+        assertEq(afterFirst, baseMultiplier + multiplier.multiplierIncrement());
+
+        // Second call in the same cycle should be a no-op
+        multiplier.updateMultiplyingFactor(testAccount);
+        uint256 afterSecond = multiplier.userToMultiplier(testAccount);
+        assertEq(afterSecond, afterFirst, "Multiplier should not change on second call in same cycle");
+    }
+
     function test_set_invalid_multiplier_increment() public {
         VotingStreakMultiplier multiplier = setUpVotingStreakMultiplier();
 


### PR DESCRIPTION
## Summary
- Adds per-cycle rate limiting to `VotingStreakMultiplier.updateMultiplyingFactor()`
- Without this fix, a user could call `updateMultiplyingFactor` repeatedly before voting to ratchet their streak to max in a single cycle
- Uses `lastClaimedBlockNumber` as the cycle identifier (changes each distribution), stored in `userLastUpdatedCycle` mapping

Closes #185

## Test plan
- [x] `test_updateMultiplyingFactor_oncePerCycle` — second call in same cycle is a no-op
- [x] `test_multiplier_reset_after_missed_cycle` — existing test still passes (streak resets correctly after missed cycles)
- [x] Existing tests pass (93/93 non-fuzz)

🤖 Generated with [Claude Code](https://claude.com/claude-code)