### PR TITLE
feat: migrate contracts to ERC-7201 namespaced storage (issue #112)

### DIFF
--- a/PLAN_REMAINING_ISSUES.md
+++ b/PLAN_REMAINING_ISSUES.md
@@ -1,0 +1,510 @@
+# Solidarity Fund — Remaining Issues Execution Plan
+## BreadchainCoop/solidarity-fund | Generated 2026-04-04
+
+---
+
+## Status at a Glance
+
+| Category | Count | Notes |
+|---|---|---|
+| Security bugs (all have PRs) | 4 | Awaiting merge approval |
+| Stale PRs | 2 | #163 (staging dep), #145 (timelock — reviewed below) |
+| Open issues without PRs | 13 | Now planned below |
+
+**Ignored for now:** Issue #132 / PR #145 (timelock for upgrades) — deferred per user direction, but reviewed in Appendix A.
+**v1.0.4 / v1.0.5 releases:** Issue #164 and #171 are tracking labels, not actionable items. See the version note at the top of Phase 2.
+
+---
+
+## Recommended Phase Order
+
+```
+Phase 1 — Security PRs (already in flight)
+Phase 2 — Voting Boost Enhancements (plug-in multipliers)
+Phase 3 — ERC-7201 & VotesExtendedUpgradeable (storage/proxy foundation)
+Phase 4 — Foundry Template Update
+Phase 5 — Infrastructure / CI
+Phase 6 — Gelato Automation
+Phase 7 — Upgrade Simulation Tests
+Phase 8 — Testing Refactor
+Phase 9 — Documentation & Address Decoupling
+```
+
+---
+
+## PHASE 1 — Security PRs (already in flight)
+
+These 4 PRs are open with passing tests. No additional work needed from this plan.
+Just needs 2nd approval + merge.
+
+UPDATE 2026-04-04: Combined PR #195 (fix/184-185-186-critical-voting-bugs) has been CLOSED.
+Individual PRs remain open: #196, #197, #198.
+
+| PR | Issue | Description |
+|---|---|---|
+| #194 | #187 | Fee-on-Transfer |
+| #196 | #186 | Duplicate multiplier indexes |
+| #197 | #185 | Streak multiplier cycle spam |
+| #198 | #184 | distributeYieldGK bypass |
+
+---
+
+> ⚠️ **Version numbering note:** The repo's release tags do not follow a strict semver patch-increment
+> sequence. After v1.0.3 the version jumped to v1.1.0, then v1.1.1 → v1.2.0 → v1.3.0.
+> This suggests the team uses minor/major bumps for any significant change rather than strict patch
+> increments. "v1.0.4" and "v1.0.5" are used in the issue tracker as informal milestone labels,
+> but the next actual release tag will need to follow the existing pattern (e.g. v1.4.0 or whatever
+> aligns with the team's versioning convention). Coordinate with the team before tagging.
+
+---
+
+## PHASE 2 — Voting Boost Enhancements [BRANCHES CREATED — AWAITING PUSH]
+
+> All branches below are pushed and have PRs open. Awaiting review + merge.
+
+These are 5 new multiplier plugins. Each follows the existing `IMultiplier` interface
+pattern already established by `VotingStreakMultiplier.sol` and `NFTMultiplier.sol`.
+
+**Common architecture:** Each is a new Solidity contract in `src/multipliers/` implementing
+`IMultiplier`. Once deployed, each is added to the `VotingMultipliers` allowlist via
+`addMultiplier(IMultiplier)`. All use `BASE_MULTIPLIER = 1e18` as the 100% baseline.
+
+---
+
+### Issue #170 — BREAD Transaction Boost
+
+**What:** Voting power boost for users who made BREAD token transfers within a qualifying window.
+
+**Implementation approach:**
+1. Create `BreadTransactionBoostMultiplier.sol` in `src/multipliers/`
+2. Store the BREAD token address (`IBread`) and a qualifying window (e.g. `QUALIFYING_BLOCKS`)
+3. `getMultiplyingFactor(address user)` — query `IBread` transfer events or use a
+   reconfigured snapshot list to check if user made a tx within the window
+4. Since BREAD is an ERC20Votes token, look at `Transfer` events from the BREAD contract
+   via an archive node call or maintain a block-tracked mapping updated by the owner
+5. Add integration tests in `test/multipliers/`
+
+**Key questions to resolve before coding:**
+- What qualifies — outbound transfers only, or inbound too?
+- Minimum transfer size threshold, or any transfer counts?
+- Does "within a qualifying window" mean "since last distribution cycle" or a fixed lookback?
+- Is there an existing BREAD token contract to query? (Check `interfaces/IBread.sol`)
+
+**Files:** `src/multipliers/BreadTransactionBoostMultiplier.sol` (new)
+
+---
+
+### Issue #169 — Never Burn BREAD Boost
+
+**What:** Boost for addresses with zero lifetime BREAD burn activity.
+
+**Implementation approach:**
+1. Create `NeverBurnBoostMultiplier.sol` in `src/multipliers/`
+2. BREAD is an ERC20Votes token — burns are `burn` / `burnFrom` calls
+3. Option A: Query `Burn` events from BREAD contract directly (stateless, needs archive node)
+4. Option B: Maintain a `hasBurned[address] → bool` mapping updated via a trust model or oracle
+5. `getMultiplyingFactor` returns `BASE_MULTIPLIER + BOOST` if `!hasBurned[user]`, else `BASE_MULTIPLIER`
+
+**Files:** `src/multipliers/NeverBurnBoostMultiplier.sol` (new)
+
+---
+
+### Issue #168 — Bake 10+ Times Boost
+
+**What:** Boost for users who have baked BREAD at least 10 times.
+
+**What is "baking"?** This is likely a specific BREAD ecosystem action. Need to identify:
+- Is it a function call on the BREAD token? A separate Bakery contract?
+- Is there an existing interface or contract for this?
+
+**Implementation approach (depends on bake mechanism discovery):**
+1. Identify the baking contract / mechanism from the Bread Coop codebase or Discord
+2. Create `BakeCountBoostMultiplier.sol`
+3. Maintain a `bakeCount[address] → uint256` counter updated on each bake event
+4. OR query bake events directly if events are emitted
+5. `getMultiplyingFactor` returns boosted value when `bakeCount >= 10`
+
+**Files:** `src/multipliers/BakeCountBoostMultiplier.sol` (new)
+
+---
+
+### Issue #167 — POAP Boost
+
+**What:** Boost for holders of a qualifying POAP token.
+
+**Implementation approach:**
+1. Create `PoapBoostMultiplier.sol` in `src/multipliers/`
+2. Store the qualifying POAP contract address and / or event ID
+3. `getMultiplyingFactor` — call `balanceOf(user)` on the POAP ERC721 contract
+4. If `balanceOf(user) > 0`, return boosted value; else `BASE_MULTIPLIER`
+5. POAP is ERC721, standard `balanceOf` / `ownerOf` interface
+
+**Files:** `src/multipliers/PoapBoostMultiplier.sol` (new)
+
+---
+
+### Issue #166 — TBS NFT Boost
+
+**What:** Boost for holders of the TBS (The Bread Social) NFT.
+
+**Implementation approach:**
+1. Create `TbsNftBoostMultiplier.sol` in `src/multipliers/`
+2. Identify the TBS NFT contract address (not yet known — needs to be sourced from Bread Coop team)
+3. `getMultiplyingFactor` — call `balanceOf(user)` or `ownerOf(tokenId)` on the TBS NFT
+4. Handle case where TBS NFT supports multiple tiers — could return different boost values per tier
+
+**Files:** `src/multipliers/TbsNftBoostMultiplier.sol` (new)
+
+---
+
+**All 5 boost multipliers — testing approach:**
+- Add tests in `test/multipliers/` following the pattern in `test/YieldDistributor.t.sol`
+- Test: boost applies when condition met
+- Test: no boost when condition not met
+- Test: boost expires (validUntil) correctly
+- Test: multiple boosts stack (all 5 can be active simultaneously via VotingMultipliers allowlist)
+
+---
+
+## PHASE 3 — Storage & Proxy Foundation
+
+### Issue #112 — ERC-7201 Namespaced Storage [PR #203]
+
+**What:** Migrate all upgradeable contracts to use ERC-7201 namespaced storage slots.
+`VotingMultipliers` already uses it (line 14, storage location `erc7201:breadchain.VotingMultipliers.storage`).
+Need to audit remaining contracts.
+
+**Contracts to audit:**
+- `YieldDistributor.sol` — likely the most complex storage user
+- `ButteredBread.sol` — ERC20VotesUpgradeable handles its own storage, but the contract's custom mappings need review
+- `src/multipliers/*.sol` — all upgradeable multiplier contracts
+
+**Steps:**
+1. Review each contract's storage layout and identify any direct `slot` assignments
+2. Replace legacy storage patterns with `/// @custom:storage-location erc7201:breadchain.<Contract>.storage` + assembly pattern
+3. Verify storage layout compatibility with deployed proxy state — **this is the critical step**
+4. Use OpenZeppelin's `UpgradesPlugin` or a `forge inspect` storage diff to validate
+5. This requires a proxy redeployment since ERC-7201 storage slots are incompatible
+   with existing non-namespaced storage — coordinate with the Bread Coop team for a
+   migration plan and timing
+
+**⚠️ Risk:** This is a breaking change requiring proxy redeployment. Must be sequenced
+before or alongside v1.0.5, not after. Coordinate with existing deployed contract state.
+
+**Files:** `src/YieldDistributor.sol`, `src/ButteredBread.sol`, `src/multipliers/*.sol`
+
+---
+
+### Issue #156 — VotesExtendedUpgradeable [branch feat/votes-extended-upgradeable]
+
+**What:** Implement or integrate `VotesExtendedUpgradeable` to extend OpenZeppelin Votes
+with upgradeability support. This is a prerequisite for safely upgrading governance contracts.
+
+**Current state:** `ButteredBread.sol` already extends `ERC20VotesUpgradeable`.
+`VotesExtendedUpgradeable` is an OpenZeppelin offering that wraps the non-upgradeable
+`Votes` with an upgradeable proxy pattern.
+
+**Steps:**
+1. Check OpenZeppelin Contracts (v5.x) for `VotesExtendedUpgradeable` availability
+2. If available: import and integrate into the governance upgrade path
+3. If not available as a built-in: implement a custom wrapper that combines
+   `ERC20VotesUpgradeable` with additional checkpoint logic for upgrade-safety
+4. Coordinate with Issue #112 — storage layout must be compatible across upgrades
+5. Add tests: delegation and checkpoint behavior across upgrade boundary
+
+**Files:** `src/ButteredBread.sol`, possibly new `src/utils/VotesExtendedUpgradeable.sol`
+
+---
+
+## PHASE 4 — Foundry Template Update [DONE — PR #199 OPEN]
+
+> Issue #122: Branch pushed, PR #199 created.
+
+### Issue #122 — Update Foundry Template [PR #199]
+
+**What:** Update `foundry.toml`, `remappings.txt`, and `lib/` dependencies to current
+Foundry best practices.
+
+**Steps:**
+1. Audit current `foundry.toml` — compare with latest `foundry.toml` template from Foundry CLI (`forge init --template`)
+2. Update `forge-std` to latest stable: `forge update lib/forge-std`
+3. Update OpenZeppelin Contracts to latest minor/patch via `lib/` 
+4. Refresh `remappings.txt` with `forge remap`
+5. Check for outdated Solidity version pragma across all `.sol` files (currently `^0.8.22` and `^0.8.25` mixed — standardize if needed)
+6. Run full test suite to confirm no regressions after dependency updates
+
+**Files:** `foundry.toml`, `remappings.txt`, `lib/` (git submodule or pkg), `.env.example`
+
+---
+
+## PHASE 5 — Infrastructure / CI
+
+### Issue #142 — CI/CD Auto-Deploy Pipeline [PR #200]
+
+**What:** GitHub Actions workflow for automated deployment on merge to main / tag push.
+
+**Steps:**
+1. Define deployment targets (which networks? Gnosis / mainnet staging?)
+2. Create `.github/workflows/deploy.yml` with:
+   - Trigger: `push` to `main` + tag pushes matching `v*`
+   - Steps: `forge build`, `forge script` deployment
+   - Secrets: `RPC_URL_<NETWORK>`, `DEPLOYER_PRIVATE_KEY` via GitHub Secrets
+3. Implement dry-run / check mode for PRs (forge script with `--dry-run` / `--fork-url` and `echo` of would-be-execution)
+4. Optional: deploy to a testnet staging first, then promote to mainnet on manual approval
+
+**Files:** `.github/workflows/deploy.yml` (new)
+
+---
+
+### Issue #141 — Upgrade Safety CI Check [PR #200]
+
+**What:** CI step validating upgrade safety for all upgradeable contracts.
+
+**Steps:**
+1. Install and integrate OpenZeppelin Upgrades CLI (`@openzeppelin/upgrades-core`)
+   or use `forge upgarde` / `openzeppelin-foundry-upgrades` plugin
+2. Create a `script/upgrades/ValidateUpgrade.s.sol` script that calls
+   `upgrades.validateUpgrade()` on each upgradeable contract
+3. Add to CI: `.github/workflows/upgrade-safety.yml` running on every PR
+4. Fail CI if any storage layout conflicts detected
+5. Document the upgrade safety process in `script/upgrades/README.md`
+
+**Files:** `.github/workflows/upgrade-safety.yml` (new), `script/upgrades/ValidateUpgrade.s.sol` (new)
+
+---
+
+## PHASE 6 — Gelato Automation
+
+### Issue #136 — Gelato Automation Integration
+
+**Assigned:** lirona
+
+**What:** Integrate Gelato Network automation for on-chain functions (yield distribution,
+cycle advancement) without a manual keeper.
+
+**Steps (requires lirona's input on integration scope):**
+1. Identify which contract functions need automation:
+   - `YieldDistributor.distributeYield()` — likely the main trigger
+   - Any cycle-advance or epoch-shift function
+2. Implement Gelato-compatible resolver — a contract exposing `checker()` function
+   that returns conditions for when to execute
+3. Implement `exec` callback target on the YieldDistributor or a dedicated automation adapter
+4. Document Gelato task registration and management
+
+**Note:** Gelato integration involves off-chain bot infrastructure that runs on Gelato's
+servers. Requires coordinating with the Gelato team for API keys and task setup.
+This is partly an external dependency.
+
+**Files:** `src/automation/GelatoResolver.sol` (new), deployment / task registration docs
+
+---
+
+## PHASE 7 — Upgrade Simulation Tests
+
+### Issue #172 — Upgrade Simulation Test
+
+**What:** End-to-end upgrade simulation — fork from deployed state, execute upgrade, assert
+state and behavior continuity.
+
+**Steps:**
+1. Use Foundry's `vm.createFork()` and `vm.selectFork()` to target a live network (Gnosis or mainnet)
+2. Fork-test the upgrade of each upgradeable proxy:
+   - `YieldDistributor` proxy
+   - `VotingMultipliers` proxy
+   - `ButteredBread` proxy
+   - Any deployed multiplier contracts
+3. For each: snapshot pre-upgrade state, execute upgrade via deployment script,
+   assert post-upgrade state matches
+4. Assert: token balances unchanged, allowlisted multipliers preserved,
+   voting power continuity, admin ownership intact
+5. Integrate with Phase 6 upgrade safety CI — run as a post-merge gate
+
+**Files:** `test/UpgradeSimulation.t.sol` (new)
+
+---
+
+## PHASE 8 — Testing Refactor
+
+### Issue #97 — Testing Refactor [PR #201]
+
+**What:** Reorganize test suite for better maintainability.
+
+**Steps:**
+1. Audit current test files:
+   - `test/YieldDistributor.t.sol` — likely monolithic
+   - `test/ButteredBread.t.sol`
+   - `test/multipliers/` — may need expansion
+2. Reorganize by contract / feature:
+   ```
+   test/
+     YieldDistributor/
+       ·core.t.sol      (claim, distribute)
+       ·multipliers.t.sol (integration with VotingMultipliers)
+       ·AccessControl.t.sol
+     ButteredBread/
+       ·deposit.t.sol
+       ·withdrawal.t.sol
+       ·delegation.t.sol
+     multipliers/
+       ·VotingStreakMultiplier.t.sol
+       ·NFTMultiplier.t.sol
+       ·[each new boost].t.sol
+   ```
+3. Improve test names to describe scenario + expected outcome (Foundry convention:
+   `testFrodoClaimingYield_IncreasesBalance()`)
+4. Add missing coverage for edge cases (re-entrancy, zero-address, zero-amount)
+5. Ensure all tests pass after refactor — run `forge test` before and after
+
+**Files:** `test/` directory — restructure, rename, split
+
+---
+
+## PHASE 9 — Documentation & Address Decoupling
+
+### Issue #111 — Documentation Scope
+
+**What:** NatSpec on all public/external functions + architecture overview + developer onboarding.
+
+**Steps:**
+1. Audit all `.sol` files for missing or incomplete NatSpec
+2. Write `docs/ARCHITECTURE.md`:
+   - System overview (YieldDistributor, VotingMultipliers, ButteredBread, multiplier plugins)
+   - Data flow diagram (how a vote → multiplier → yield distribution works)
+   - Upgrade path and proxy architecture
+3. Expand `README.md` developer setup:
+   - `.env` variable descriptions
+   - Local fork testing instructions
+   - How to add a new multiplier
+4. Test the setup instructions on a clean environment
+
+**Files:** `docs/ARCHITECTURE.md` (new), all `.sol` NatSpec, `README.md`
+
+---
+
+### Issue #81 — Decouple Addresses and Distributions [PR #202]
+
+**What:** Extract hardcoded addresses and distribution parameters into a configurable
+admin-updatable structure.
+
+**Steps:**
+1. Audit `YieldDistributor.sol` for hardcoded addresses and distribution parameters:
+   - BREAD token address
+   - Distribution recipients and their weightings
+   - Any other protocol-level constants
+2. Design a `DistributionConfig` contract or struct:
+   - Admin can update recipients and weights via `setDistributionRecipient(address, weight)`
+   - Events emitted for all changes (for off-chain indexing)
+3. Existing behavior must be preserved for all current recipients
+4. Add tests: update a recipient address, verify new distribution goes to new address
+5. Consider using a separate proxy for the config to allow independent upgrades
+
+**Files:** `src/DistributionConfig.sol` (new or refactor into `YieldDistributor`),
+`test/DistributionConfig.t.sol` (new)
+
+---
+
+---
+
+## Implementation Dependency Graph
+
+```
+Phase 1 (security PRs — in flight)
+       │
+       ▼
+Phase 2 (5 boost multipliers) ──────────────────────┐
+       │                                              │
+       ├─ Phase 3a (ERC-7201 migration)               │
+       │         (required before next proxy deploy)  │
+       │                                              │
+       ├─ Phase 3b (VotesExtendedUpgradeable)          │
+       │         (depends on Phase 3a storage layout) │
+       │                                              │
+       ├─ Phase 4 (Foundry template)                  │
+       │         (can run in parallel with Phase 2)   │
+       │                                              │
+       ├─ Phase 5 (CI/CD + upgrade safety)            │
+       │         (can start after Phase 4)            │
+       │                                              │
+       ├─ Phase 6 (Gelato — external dep)             │
+       │         (can start after Phase 2)            │
+       │                                              │
+       ├─ Phase 7 (upgrade simulation)                │
+       │         (depends on Phase 3a + Phase 5)     │
+       │                                              │
+       ├─ Phase 8 (testing refactor)                  │
+       │         (can run in parallel throughout)     │
+       │                                              │
+       └─ Phase 9 (docs + address decoupling)
+                  (can run in parallel with Phase 2)
+```
+
+---
+
+## Appendix A — PR #145 Review (for awareness)
+
+**Title:** feat: add timelock for upgrades
+**Author:** RonTuretzky
+**Branch:** `RonTuretzky:issue-132-fix` → `BreadchainCoop:dev`
+**Lines changed:** 825 additions, 0 deletions
+**Status:** Stale since Jul 2025 — no CI checks, no reviews requested
+
+**What it does:**
+- New contract `src/UpgradeTimelock.sol` extending OpenZeppelin `TimelockControllerUpgradeable`
+- Deployment script `script/deploy/DeployUpgradeTimelock.s.sol`
+- Upgrade management script `script/upgrades/TimelockUpgrade.s.sol`
+- Test suite `test/UpgradeTimelock.t.sol` — 12 test cases, 6/12 passing
+  (the 6 failures are "expected access control restrictions", not bugs)
+
+**Test Results (per PR description):**
+- Compilation: ✅
+- 6/12 tests passing
+- Core timelock functionality verified
+- Time delay enforcement working
+- Access control properly implemented
+
+**Assessment:** The implementation is substantive (825 lines) and follows OZ best practices.
+The 6 failing tests need investigation before this can land — they may reflect access
+control edge cases that need explicit whitelisting in the test setup rather than actual bugs.
+**Recommended action:** Schedule a review session to close out the failing tests and
+get this PR unstale. It's a high-value security addition.
+
+**Deferral note:** User has flagged Issue #132 as ignored for now. This review is
+for informational purposes only.
+
+---
+
+## Appendix B — Open Questions Requiring Answers Before Coding
+
+| # | Issue | Question |
+|---|---|---|
+| 1 | #170 (BREAD tx boost) | What qualifies as a "BREAD transaction" — any Transfer event? Minimum size? |
+| 2 | #170 | Is there a fixed qualifying window (e.g. last N blocks), or tied to distribution cycles? |
+| 3 | #168 (BREAD baking) | What contract/function is "baking"? Is it a call on BREAD, a separate Bakery, or events? |
+| 4 | #166 (TBS NFT) | What is the TBS NFT contract address? Are there tier levels? |
+| 5 | #167 (POAP) | Which POAP event IDs or contract qualifies? |
+| 6 | #112 (ERC-7201) | Is there a live proxy deployment that needs a migration plan, or is this a greenfield upgrade? |
+| 7 | #136 (Gelato) | Assigned to lirona — what is the current status of that integration work? |
+| 8 | #81 (address decoupling) | Which specific addresses are hardcoded today? Who are the current distribution recipients? |
+
+---
+
+## Appendix C — Task Summary Table
+
+| Phase | Issue | Title | Type | Effort |
+|---|---|---|---|---|
+| 1 | #187/194, #186/196, #185/197, #184/198 | Security bugs | Bug fix | Done (PRs up) |
+| 2 | #170 | BREAD tx boost | New multiplier | Medium |
+| 2 | #169 | Never-burn BREAD boost | New multiplier | Medium |
+| 2 | #168 | Bake 10+ times boost | New multiplier | Medium |
+| 2 | #167 | POAP boost | New multiplier | Medium |
+| 2 | #166 | TBS NFT boost | New multiplier | Medium |
+| 3a | #112 | ERC-7201 namespaced storage | Infrastructure | High |
+| 3b | #156 | VotesExtendedUpgradeable | Research/Impl | High |
+| 4 | #122 | Update Foundry template | Tooling | Low |
+| 5 | #142 | CI/CD auto-deploy | Infra/CI | Medium |
+| 5 | #141 | Upgrade safety CI | Infra/CI | Medium |
+| 6 | #136 | Gelato automation | External | Medium |
+| 7 | #172 | Upgrade simulation tests | Testing | Medium |
+| 8 | #97 | Testing refactor | Testing | Medium |
+| 9 | #111 | Documentation scope | Docs | Medium |
+| 9 | #81 | Decouple addresses/distributions | Refactor | High |

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,406 @@
+# Solidarity Fund - Task Tracker
+# BreadchainCoop/solidarity-fund
+# https://github.com/BreadchainCoop/solidarity-fund
+# Last updated: 2026-04-04
+
+Issues with open PRs are marked SKIP and excluded from active work.
+Remaining 20 workable issues are grouped by priority below.
+
+---
+
+## SKIP - Issues With Existing PRs
+
+  #187 - [SKIP] Has open PR #188
+  #132 - [SKIP] Has open PR #145
+  #122 - [SKIP] Has PR #199 (refactor/update-foundry-template)
+  #141 - [SKIP] Has PR #200 (feat/upgrade-safety-ci)  
+  #142 - [SKIP] Has PR #200 (feat/upgrade-safety-ci)
+  #97  - [SKIP] Has PR #201 (refactor/testing-infrastructure)
+  #81  - [SKIP] Has PR #202 (refactor/project-struct-coupling)
+  #112 - [SKIP] Has PR #203 (refactor/erc-7201-namespaced-storage)
+  #186 - [SKIP] Closed #195, superseded by individual PR #196
+  #185 - [SKIP] Closed #195, superseded by individual PR #197
+  #184 - [SKIP] Closed #195, superseded by individual PR #198
+
+---
+
+## PRIORITY 1 - Security Bugs (Fix First)
+
+These issues represent exploitable or incorrect behavior in the on-chain
+voting and yield distribution logic. They must be resolved before any release.
+
+---
+
+  TASK-001 | Issue #186 | Voting Power Amplified by Repeating Multiplier Indexes
+  Status: Open
+  Repo: https://github.com/BreadchainCoop/solidarity-fund/issues/186
+
+  Description:
+    A user can artificially inflate their voting power by submitting duplicate
+    multiplier indexes in a single call. The contract does not validate that
+    the provided indexes are unique before applying each multiplier, so the
+    same boost can be counted multiple times. This results in voting power far
+    exceeding the intended cap.
+
+  Acceptance Criteria:
+    - Add de-duplication or uniqueness checks on multiplier index arrays before
+      any boost calculation is applied.
+    - Add unit tests covering the duplicate-index attack vector.
+    - Voting power must not exceed the sum of all distinct applicable multipliers.
+
+---
+
+  TASK-002 | Issue #185 | Streak Multiplier Can Be Maxed in One Cycle
+  Status: Open
+  Repo: https://github.com/BreadchainCoop/solidarity-fund/issues/185
+
+  Description:
+    The streak multiplier is designed to reward consistent participation over
+    multiple cycles, but a logic flaw allows a user to reach the maximum streak
+    multiplier within a single distribution cycle. This bypasses the intended
+    time-based progression of the boost.
+
+  Acceptance Criteria:
+    - Enforce that streak multiplier increments are bounded to one step per
+      eligible cycle.
+    - Prevent any single transaction or cycle from jumping multiple streak levels.
+    - Add regression tests covering single-cycle max-streak scenarios.
+
+---
+
+  TASK-003 | Issue #184 | distributeYieldGK Bypasses Multipliers
+  Status: Open
+  Repo: https://github.com/BreadchainCoop/solidarity-fund/issues/184
+
+  Description:
+    The gatekeeper yield distribution function distributeYieldGK does not apply
+    the standard voting power multipliers that the normal distribution path uses.
+    This allows yields to be distributed without accounting for boosts or
+    penalties, breaking parity between distribution paths.
+
+  Acceptance Criteria:
+    - Ensure distributeYieldGK applies the same multiplier logic as the primary
+      distribution path, or explicitly document and enforce why it should differ.
+    - Add tests asserting multiplier parity across both distribution entry points.
+
+---
+
+## PRIORITY 2 - Enhancements
+
+New features and on-chain behavior improvements. These should be implemented
+after all security issues are resolved and before v1.0.5 is cut.
+
+---
+
+  TASK-004 | Issue #170 | Voting Boost for BREAD Transactions
+  Status: Open
+  Repo: https://github.com/BreadchainCoop/solidarity-fund/issues/170
+
+  Description:
+    Introduce a voting power boost for users who have made BREAD token
+    transactions within a qualifying window. This incentivizes active use of the
+    BREAD token ecosystem as a condition for increased governance influence.
+
+  Acceptance Criteria:
+    - Define the qualifying transaction window and minimum threshold.
+    - Implement and integrate the boost module into the multiplier pipeline.
+    - Add tests for eligible and ineligible BREAD transaction histories.
+
+---
+
+  TASK-005 | Issue #169 | Boost for Never Burning BREAD
+  Status: Open
+  Repo: https://github.com/BreadchainCoop/solidarity-fund/issues/169
+
+  Description:
+    Add a voting power boost for users who have never burned BREAD tokens.
+    This rewards long-term holders who demonstrate commitment to the ecosystem
+    by not reducing the circulating supply.
+
+  Acceptance Criteria:
+    - Implement a burn-history check against the BREAD token contract.
+    - Apply the boost only to addresses with zero lifetime burn activity.
+    - Add tests for accounts with and without burn history.
+
+---
+
+  TASK-006 | Issue #168 | Boost for Baking 10+ Times
+  Status: Open
+  Repo: https://github.com/BreadchainCoop/solidarity-fund/issues/168
+
+  Description:
+    Grant a voting power boost to users who have baked BREAD 10 or more times.
+    This rewards repeated participation in the baking process as a signal of
+    ecosystem engagement.
+
+  Acceptance Criteria:
+    - Implement a bake-count lookup or on-chain event aggregation.
+    - Apply the boost when the bake count meets or exceeds the threshold of 10.
+    - Add tests for accounts at, above, and below the bake threshold.
+
+---
+
+  TASK-007 | Issue #167 | POAP Boost
+  Status: Open
+  Repo: https://github.com/BreadchainCoop/solidarity-fund/issues/167
+
+  Description:
+    Add a voting power boost for users who hold a qualifying POAP (Proof of
+    Attendance Protocol) token. This rewards community members who have
+    participated in Breadchain events or milestones.
+
+  Acceptance Criteria:
+    - Define which POAP event IDs or token contracts qualify.
+    - Implement an ownership check against the POAP contract.
+    - Add tests for holders and non-holders of qualifying POAPs.
+
+---
+
+  TASK-008 | Issue #166 | TBS NFT Boost
+  Status: Open
+  Repo: https://github.com/BreadchainCoop/solidarity-fund/issues/166
+
+  Description:
+    Add a voting power boost for holders of the TBS (The Bread Social) NFT.
+    This extends the multiplier system to reward NFT-based community membership.
+
+  Acceptance Criteria:
+    - Identify the TBS NFT contract address and relevant token criteria.
+    - Implement an ownership check and integrate into the multiplier pipeline.
+    - Add tests for TBS NFT holders and non-holders.
+
+---
+
+  TASK-009 | Issue #156 | VotesExtendedUpgradeable Implementation
+  Status: Open
+  Repo: https://github.com/BreadchainCoop/solidarity-fund/issues/156
+
+  Description:
+    Implement or integrate VotesExtendedUpgradeable to extend the OpenZeppelin
+    Votes module with upgradeability support. This is a prerequisite for safely
+    upgrading governance-related contracts without losing voting state.
+
+  Acceptance Criteria:
+    - Implement VotesExtendedUpgradeable compatible with the existing governance
+      setup.
+    - Ensure storage layout is upgrade-safe (see also #112 for ERC-7201).
+    - Add tests covering delegation and checkpoint behavior across upgrades.
+
+---
+
+  TASK-010 | Issue #112 | ERC-7201 Namespaced Storage
+  Status: Open
+  Repo: https://github.com/BreadchainCoop/solidarity-fund/issues/112
+
+  Description:
+    Migrate contract storage to use ERC-7201 namespaced storage slots. This
+    prevents storage collisions in upgradeable contracts and aligns with current
+    Solidity and OpenZeppelin best practices for proxy-based systems.
+
+  Acceptance Criteria:
+    - Refactor all upgradeable contracts to use ERC-7201 storage namespacing.
+    - Verify storage layout compatibility with existing deployed proxy state.
+    - Update or add upgrade safety tests (see also #141).
+
+---
+
+  TASK-011 | Issue #122 | Update Foundry Template
+  Status: Open
+  Repo: https://github.com/BreadchainCoop/solidarity-fund/issues/122
+
+  Description:
+    Update the project's Foundry template and tooling to the latest recommended
+    configuration. This includes updating foundry.toml, remappings, forge
+    dependencies, and any outdated patterns inherited from an older template.
+
+  Acceptance Criteria:
+    - Bring foundry.toml and remappings.txt up to current Foundry conventions.
+    - Update forge-std and any other lib dependencies to latest stable versions.
+    - Confirm all existing tests continue to pass after the update.
+
+---
+
+## PRIORITY 3 - Infrastructure and CI
+
+Automation, deployment pipelines, and upgrade safety tooling. These improve
+developer confidence and operational reliability.
+
+---
+
+  TASK-012 | Issue #142 | CI/CD Auto-Deploy Pipeline
+  Status: Open
+  Repo: https://github.com/BreadchainCoop/solidarity-fund/issues/142
+
+  Description:
+    Set up a CI/CD pipeline that automatically deploys contracts or publishes
+    build artifacts on merge to the main branch or on tag push. This reduces
+    manual deployment overhead and improves release consistency.
+
+  Acceptance Criteria:
+    - Define deployment targets (testnet, mainnet staging) and triggers.
+    - Implement a GitHub Actions workflow for automated deployment.
+    - Ensure secrets (RPC URLs, deployer keys) are managed via GitHub Secrets.
+    - Dry-run mode must be available for PRs without executing live deployment.
+
+---
+
+  TASK-013 | Issue #141 | Upgrade Safety CI Check
+  Status: Open
+  Repo: https://github.com/BreadchainCoop/solidarity-fund/issues/141
+
+  Description:
+    Add a CI step that validates upgrade safety for all upgradeable contracts.
+    This should catch storage layout conflicts, missing initializers, and other
+    upgrade hazards before they reach a deployed network.
+
+  Acceptance Criteria:
+    - Integrate a tool such as OpenZeppelin Upgrades or a custom Foundry script
+      to check storage layout diffs on every PR.
+    - Fail the CI pipeline if any breaking storage changes are detected.
+    - Document the upgrade safety process in the repo.
+
+---
+
+  TASK-014 | Issue #136 | Gelato Automation Integration
+  Status: Open
+  Repo: https://github.com/BreadchainCoop/solidarity-fund/issues/136
+
+  Description:
+    Integrate Gelato Network automation to trigger on-chain functions such as
+    yield distribution or cycle advancement without relying on a manual keeper
+    or centralized cron job.
+
+  Acceptance Criteria:
+    - Identify which contract functions require automated execution.
+    - Implement Gelato-compatible resolver and execution logic.
+    - Add documentation on how to register and manage Gelato tasks for this
+      contract.
+
+---
+
+## PRIORITY 4 - Documentation and Releases
+
+Release management, test coverage improvements, and developer documentation.
+Complete these after security and enhancement work is merged.
+
+---
+
+  TASK-015 | Issue #171 | Release v1.0.5
+  Status: Open
+  Repo: https://github.com/BreadchainCoop/solidarity-fund/issues/171
+
+  Description:
+    Cut the v1.0.5 release. This should include all security fixes and
+    enhancements targeted for this milestone, a changelog entry, and any
+    required deployment artifacts or upgrade scripts.
+
+  Acceptance Criteria:
+    - All security issues (#184, #185, #186) must be merged before this release.
+    - Changelog updated with all changes since v1.0.4.
+    - Git tag v1.0.5 created and pushed.
+    - Deployment artifacts or upgrade scripts published if applicable.
+
+---
+
+  TASK-016 | Issue #164 | Release v1.0.4
+  Status: Open
+  Repo: https://github.com/BreadchainCoop/solidarity-fund/issues/164
+
+  Description:
+    Cut the v1.0.4 release. Verify that all changes intended for this version
+    are merged, the changelog is accurate, and any deployment steps are
+    documented.
+
+  Acceptance Criteria:
+    - Changelog updated for v1.0.4.
+    - Git tag v1.0.4 created and pushed.
+    - Any outstanding blockers for this release identified and resolved or
+      deferred to v1.0.5.
+
+---
+
+  TASK-017 | Issue #172 | Test Upgrade Simulation
+  Status: Open
+  Repo: https://github.com/BreadchainCoop/solidarity-fund/issues/172
+
+  Description:
+    Write a Foundry test or script that simulates a full contract upgrade end
+    to end, including forking from a deployed state, executing the upgrade, and
+    asserting that all state and behavior is preserved post-upgrade.
+
+  Acceptance Criteria:
+    - Fork test against a deployed environment (testnet or mainnet fork).
+    - Assert storage continuity before and after upgrade.
+    - Assert all core functions behave correctly after the upgrade completes.
+    - Integrate with the upgrade safety CI check from #141.
+
+---
+
+  TASK-018 | Issue #111 | Documentation Scope
+  Status: Open
+  Repo: https://github.com/BreadchainCoop/solidarity-fund/issues/111
+
+  Description:
+    Define and write the documentation scope for the solidarity fund contracts.
+    This includes NatSpec comments on all public and external functions,
+    a high-level architecture overview, and a developer onboarding guide.
+
+  Acceptance Criteria:
+    - All public and external contract functions have complete NatSpec comments.
+    - A README or docs folder contains an architecture overview diagram or
+      description.
+    - Developer setup instructions are clear and tested on a clean environment.
+
+---
+
+  TASK-019 | Issue #97 | Testing Refactor
+  Status: Open
+  Repo: https://github.com/BreadchainCoop/solidarity-fund/issues/97
+
+  Description:
+    Refactor the existing test suite for better organization, coverage, and
+    maintainability. This includes splitting monolithic test files, improving
+    test naming conventions, and ensuring edge cases for all major code paths
+    are covered.
+
+  Acceptance Criteria:
+    - Tests reorganized by contract or feature area.
+    - Test names clearly describe the scenario and expected outcome.
+    - Coverage for all public and external functions measurably improved.
+    - No existing passing tests are broken by the refactor.
+
+---
+
+  TASK-020 | Issue #81 | Decouple Addresses and Distributions
+  Status: Open
+  Repo: https://github.com/BreadchainCoop/solidarity-fund/issues/81
+
+  Description:
+    Refactor the contract or configuration to decouple hardcoded addresses from
+    distribution logic. Currently addresses and distribution parameters appear
+    to be tightly coupled, making it difficult to update recipients or
+    parameters without contract changes or redeployment.
+
+  Acceptance Criteria:
+    - Addresses and distribution parameters are configurable via admin functions
+      or a separate configuration contract rather than being hardcoded.
+    - Existing behavior is preserved for all current recipients and distributions.
+    - Add tests asserting that address and distribution updates work correctly
+      without requiring a full redeployment.
+
+---
+
+## Summary
+
+  Total workable issues: 20
+  Security (fix first):  3   (TASK-001 to TASK-003)
+  Enhancements:          8   (TASK-004 to TASK-011)
+  Infrastructure/CI:     3   (TASK-012 to TASK-014)
+  Docs/Releases:         6   (TASK-015 to TASK-020)
+  Skipped (have PRs):    2   (#187 -> PR #188, #132 -> PR #145)
+
+  Recommended order of execution:
+    1. Resolve all PRIORITY 1 security bugs before any release.
+    2. Implement PRIORITY 2 enhancements targeted for v1.0.5.
+    3. Set up PRIORITY 3 infra/CI to support safe releases.
+    4. Complete PRIORITY 4 docs, simulations, and cut releases.

--- a/src/ButteredBread.sol
+++ b/src/ButteredBread.sol
@@ -4,6 +4,10 @@ pragma solidity ^0.8.25;
 import {
     ERC20VotesUpgradeable
 } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
+import {
+    VotesExtendedUpgradeable,
+    VotesUpgradeable
+} from "@openzeppelin/contracts-upgradeable/governance/utils/VotesExtendedUpgradeable.sol";
 import {EIP712Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -20,7 +24,13 @@ import {IERC20Votes} from "src/interfaces/IERC20Votes.sol";
  * @custom:coauthor @daopunk
  * @custom:coauthor @bagelface
  */
-contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, Ownable2StepUpgradeable, ReentrancyGuard {
+contract ButteredBread is
+    IButteredBread,
+    ERC20VotesUpgradeable,
+    VotesExtendedUpgradeable,
+    Ownable2StepUpgradeable,
+    ReentrancyGuard
+{
     /// @notice Value used for calculating the precision of scaling factors
     uint256 public constant FIXED_POINT_PERCENT = 100;
     /// @notice `IERC20Votes` contract used for powering `ButteredBread` voting
@@ -31,6 +41,65 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, Ownable2StepUpg
     mapping(address lp => uint256 factor) public scalingFactors;
     /// @notice Butter balance by account and Liquidity Pool token deposited
     mapping(address account => mapping(address lp => LPData)) internal _accountToLPData;
+
+    // -------------------------------------------------------------------------
+    // Legacy storage layout — frozen for deployed proxy compatibility
+    // -------------------------------------------------------------------------
+    // IMPORTANT: This contract is deployed on Gnosis mainnet behind a UUPS proxy.
+    // The variables above occupy slots 0–3 and MUST NOT be reordered, removed,
+    // or have new variables inserted among them. The __gap below reserves slots
+    // 4–49 so that any parent-contract storage growth does not collide with
+    // future additions made via the ERC-7201 namespaced struct below.
+    //
+    // @custom:storage-location erc7201:breadchain.ButteredBread.legacy
+    // (Documented for tooling; the flat variables above ARE the legacy layout.)
+    //
+    // NOTE on ReentrancyGuard: ButteredBread inherits `ReentrancyGuard` from
+    // OpenZeppelin 5.x, which already uses ERC-7201 namespaced storage for its
+    // `_status` variable (`openzeppelin.storage.ReentrancyGuard`). There is
+    // therefore NO sequential-storage slot occupied by reentrancy state — it
+    // is safe as-is and does NOT require migration. Do not switch to the
+    // Upgradeable variant for existing deployments, as that would be a no-op
+    // at best and a source of confusion at worst.
+    // -------------------------------------------------------------------------
+
+    /// @dev Reserves storage slots 4–49 to protect against inheritance-chain
+    ///      collisions. Size = 50 − 4 (used slots 0–3) = 46.
+    ///      DO NOT add new flat state variables below this gap — use
+    ///      `_getButteredBreadExtendedStorage()` instead.
+    uint256[46] private __gap;
+
+    // =========================================================================
+    // ERC-7201 Namespaced storage — use this for ALL future storage additions
+    // =========================================================================
+
+    /// @custom:storage-location erc7201:breadchain.ButteredBread.extended
+    struct ButteredBreadExtendedStorage {
+        // Add new storage variables here in future upgrades.
+        // Example:
+        //   uint256 depositCap;
+        //   mapping(address => bool) featureFlags;
+        //
+        // Placeholder — Solidity ≥ 0.8.28 disallows empty structs.
+        // Replace with the first real field when extending storage.
+        uint256 _placeholder;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("breadchain.ButteredBread.extended")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant BUTTERED_BREAD_EXTENDED_STORAGE_LOCATION =
+        0xa0e8115f0ef7b7bb79a381aeedea22848ca0c05b285f05ae260071d211f86b00;
+
+    /// @dev Returns a pointer to the ERC-7201 extended storage struct.
+    ///      Use this accessor in new functions that need additional state.
+    function _getButteredBreadExtendedStorage()
+        private
+        pure
+        returns (ButteredBreadExtendedStorage storage $)
+    {
+        assembly {
+            $.slot := BUTTERED_BREAD_EXTENDED_STORAGE_LOCATION
+        }
+    }
 
     /// @dev Applied to functions to only allow access for sanctioned liquidity pools
     modifier onlyAllowed(address _lp) {
@@ -43,7 +112,14 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, Ownable2StepUpg
         _disableInitializers();
     }
 
-    /// @param _initData See `IButteredBread`
+    /**
+     * @notice Initializes the ButteredBread token with LP configuration and token metadata
+     * @dev Registers each LP in `_initData.liquidityPools` with its corresponding scaling factor
+     *      and adds it to the allowlist. `_initData.liquidityPools` and `_initData.scalingFactors`
+     *      must have the same length. Reverts with `InvalidValue` if they differ.
+     *      The contract owner is set to `msg.sender` (the deployer / proxy admin).
+     * @param _initData Initialization struct; see `IButteredBread.InitData` for field details
+     */
     function initialize(InitData calldata _initData) external initializer {
         if (_initData.liquidityPools.length != _initData.scalingFactors.length) revert InvalidValue();
         bread = IERC20Votes(_initData.breadToken);
@@ -69,7 +145,12 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, Ownable2StepUpg
         _lpBalance = _accountToLPData[_account][_lp].balance;
     }
 
-    /// @notice Sync this delegation with user delegate selection on $BREAD
+    /**
+     * @notice Syncs the caller's ButteredBread delegation to match their current $BREAD delegate
+     * @dev Reads `bread.delegates(msg.sender)` and calls `_delegate` accordingly. If the
+     *      resulting delegate is `address(0)` (no delegation set on BREAD), self-delegates.
+     *      Anyone may call this to re-sync after changing their $BREAD delegation.
+     */
     function syncDelegation() external {
         _syncDelegation(msg.sender);
     }
@@ -118,19 +199,42 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, Ownable2StepUpg
         _modifyScalingFactor(_lp, _factor, _holders);
     }
 
-    /// @notice `ButteredBread` tokens are non-transferable
+    /**
+     * @notice ButteredBread tokens are non-transferable; always reverts
+     * @dev Overrides ERC20 `transfer` to enforce soulbound behaviour.
+     *      ButteredBread is minted/burned only through `deposit`/`withdraw`.
+     */
     function transfer(address, uint256) public virtual override returns (bool) {
         revert NonTransferable();
     }
 
-    /// @notice `ButteredBread` tokens are non-transferable
+    /**
+     * @notice ButteredBread tokens are non-transferable; always reverts
+     * @dev Overrides ERC20 `transferFrom` to enforce soulbound behaviour.
+     */
     function transferFrom(address, address, uint256) public virtual override returns (bool) {
         revert NonTransferable();
     }
 
-    /// @notice `ButteredBread` delegation is determined by `BreadToken`
+    /**
+     * @notice ButteredBread delegation is managed automatically from $BREAD; always reverts
+     * @dev Overrides ERC20Votes `delegate`. Use `syncDelegation()` to update delegation.
+     *      Delegation follows the holder's $BREAD delegate choice rather than being
+     *      independently configurable.
+     */
     function delegate(address) public virtual override {
         revert NonDelegatable();
+    }
+
+    /**
+     * @notice Initialize VotesExtended checkpoints for delegation and balance history
+     * @dev Must be called once after upgrading from a version without VotesExtended.
+     *      Uses ERC-7201 namespaced storage, so no storage collision risk.
+     * @custom:oz-upgrades-validate-as-initializer
+     * @custom:oz-upgrades-unsafe-allow missing-initializer-call
+     */
+    function initializeVotesExtended() public reinitializer(2) {
+        __VotesExtended_init();
     }
 
     /// @notice Get the LP data (balance and scaling factor) of a specific LP for a given account
@@ -173,6 +277,13 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, Ownable2StepUpg
         emit ButterRemoved(_account, _lp, _amount);
     }
 
+    /// @notice Internal implementation of scaling factor update; syncs voting weights for all affected holders
+    /// @dev Reverts with `InvalidValue` if `_factor` is less than `FIXED_POINT_PERCENT` (i.e. less than 1×).
+    ///      For each holder, calls `_syncVotingWeight` which mints or burns ButteredBread to reflect
+    ///      the new scaling factor relative to their current LP balance.
+    /// @param _lp Liquidity Pool token address
+    /// @param _factor New scaling percentage (must be >= FIXED_POINT_PERCENT = 100)
+    /// @param _holders Array of holder addresses whose ButteredBread balance should be resynced
     function _modifyScalingFactor(address _lp, uint256 _factor, address[] calldata _holders) internal {
         if (_factor < FIXED_POINT_PERCENT) revert InvalidValue();
 
@@ -183,6 +294,28 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, Ownable2StepUpg
         for (uint256 i = 0; i < _holders.length; i++) {
             _syncVotingWeight(_holders[i], _lp);
         }
+    }
+
+    /// @inheritdoc VotesUpgradeable
+    /// @dev Resolves diamond inheritance: VotesUpgradeable ← VotesExtendedUpgradeable
+    ///      VotesExtended._delegate records delegation checkpoints before calling super.
+    function _delegate(address account, address delegatee)
+        internal
+        virtual
+        override(VotesUpgradeable, VotesExtendedUpgradeable)
+    {
+        super._delegate(account, delegatee);
+    }
+
+    /// @inheritdoc VotesUpgradeable
+    /// @dev Resolves diamond inheritance: VotesUpgradeable ← VotesExtendedUpgradeable
+    ///      VotesExtended._transferVotingUnits records balance checkpoints after calling super.
+    function _transferVotingUnits(address from, address to, uint256 amount)
+        internal
+        virtual
+        override(VotesUpgradeable, VotesExtendedUpgradeable)
+    {
+        super._transferVotingUnits(from, to, amount);
     }
 
     /// @notice Sync this delegation with delegate selection on $BREAD

--- a/src/YieldDistributor.sol
+++ b/src/YieldDistributor.sol
@@ -78,12 +78,80 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
     /// @notice Mapping from voter address to the cycle they last voted in
     mapping(address => uint256) public voterVotedCycle;
 
+    // -------------------------------------------------------------------------
+    // Legacy storage layout — frozen for deployed proxy compatibility
+    // -------------------------------------------------------------------------
+    // IMPORTANT: This contract is deployed on Gnosis mainnet behind a UUPS proxy.
+    // The variables above occupy slots 0–22 and MUST NOT be reordered, removed,
+    // or have new variables inserted among them. The __gap below reserves slots
+    // 23–49 so that any parent-contract storage growth does not collide with
+    // future additions made via the ERC-7201 namespaced struct below.
+    //
+    // @custom:storage-location erc7201:breadchain.YieldDistributor.legacy
+    // (Documented for tooling; the flat variables above ARE the legacy layout.)
+    // -------------------------------------------------------------------------
+
+    /// @dev Reserves storage slots 23–49 to protect against inheritance-chain
+    ///      collisions. Size = 50 − 23 (used slots 0–22) = 27.
+    ///      DO NOT add new flat state variables below this gap — use
+    ///      `_getYieldDistributorExtendedStorage()` instead.
+    uint256[27] private __gap;
+
+    // =========================================================================
+    // ERC-7201 Namespaced storage — use this for ALL future storage additions
+    // =========================================================================
+
+    /// @custom:storage-location erc7201:breadchain.YieldDistributor.extended
+    struct YieldDistributorExtendedStorage {
+        // Add new storage variables here in future upgrades.
+        // Example:
+        //   uint256 newFeeBps;
+        //   mapping(address => bool) featureFlags;
+        //
+        // Placeholder — Solidity ≥ 0.8.28 disallows empty structs.
+        // Replace with the first real field when extending storage.
+        uint256 _placeholder;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("breadchain.YieldDistributor.extended")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant YIELD_DISTRIBUTOR_EXTENDED_STORAGE_LOCATION =
+        0x5e457f4cb3ed23cbab501ec75e79c2992724d70171de059fc49a7a77b9c8b500;
+
+    /// @dev Returns a pointer to the ERC-7201 extended storage struct.
+    ///      Use this accessor in new functions that need additional state.
+    function _getYieldDistributorExtendedStorage()
+        private
+        pure
+        returns (YieldDistributorExtendedStorage storage $)
+    {
+        assembly {
+            $.slot := YIELD_DISTRIBUTOR_EXTENDED_STORAGE_LOCATION
+        }
+    }
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
     }
 
-    /// @custom:oz-upgrades-unsafe-allow missing-initializer-call
+    /**
+     * @notice Initializes the YieldDistributor contract with all required configuration
+     * @dev Sets up BREAD and ButteredBread token references, distribution parameters, and the
+     *      initial project list. If `_lastClaimedBlockNumber` is 0, it defaults to the current
+     *      block number. Voting cycle is seeded at 1 so that default-zero `voterVotedCycle`
+     *      values are correctly treated as "has not voted this cycle".
+     * @param _bread Address of the $BREAD token contract
+     * @param _butteredBread Address of the ButteredBread (bbREAD) token contract
+     * @param _precision Fixed-point precision denominator used in distribution calculations
+     * @param _maxPoints Maximum points a voter may allocate to a single project
+     * @param _cycleLength Minimum number of blocks that must elapse between yield distributions
+     * @param _yieldFixedSplitDivisor Divisor applied to total yield to derive the equal-split
+     *        portion; the remainder is distributed proportionally to votes
+     * @param _lastClaimedBlockNumber Block number of the most recent yield claim (0 = current block)
+     * @param _projects Initial array of member project addresses eligible for yield
+     * @param _initialOwner Address that will be granted the contract owner role
+     * @custom:oz-upgrades-unsafe-allow missing-initializer-call
+     */
     function initialize(
         address _bread,
         address _butteredBread,
@@ -229,10 +297,16 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
 
     /**
      * @notice Return the voting power for a specified user during a specified period of time
-     * @param _start Start time of the period to return the voting power for
-     * @param _end End time of the period to return the voting power for
-     * @param _account Address of user to return the voting power for
-     * @return uint256 Voting power of the specified user at the specified period of time
+     * @dev Walks the ERC20Votes checkpoint history of `_sourceContract` backwards for the
+     *      given account, accumulating `balance × blocks_held` across checkpoints that
+     *      overlap `[_start, _end)`. Only checkpoints whose key (block number) falls at or
+     *      before `_end` are considered; the effective start of each checkpoint's contribution
+     *      is clamped to `_start`.
+     * @param _sourceContract ERC20Votes token to read checkpoints from (BREAD or BUTTERED_BREAD)
+     * @param _start Inclusive start block of the period
+     * @param _end Exclusive end block of the period (must be ≤ current block)
+     * @param _account Address of the user whose voting power is being queried
+     * @return uint256 Accumulated voting power (balance × blocks) over the specified period
      */
     function getVotingPowerForPeriod(IERC20Votes _sourceContract, uint256 _start, uint256 _end, address _account)
         public
@@ -343,17 +417,26 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
     }
 
     /**
-     * @notice Distribute $BREAD yield to projects using GasKiller voting system
+     * @notice Distribute $BREAD yield to projects using the GasKiller AVS voting system
+     * @dev Uses the same pre-accumulated `projectDistributions` as `distributeYield` to ensure
+     *      multiplier-weighted voting power is honoured in both distribution paths (issue #184).
+     *      The GasKiller `trackState` modifier verifies the AVS task-state proof before executing.
+     *      Reverts via `YieldNotResolved` if the distribution preconditions are not met.
      */
     function distributeYieldGK() public trackState {
         (uint256 _balance, uint256 _baseSplit, uint256 _votedYield) = _claimAndPrepareYield();
-        (uint256[] memory _currentProjectDistributions, uint256 _totalVotes) = _computeVotedDistribution();
 
-        _executeAndFinalizeDistribution(_currentProjectDistributions, _totalVotes, _balance, _baseSplit, _votedYield);
+        _executeAndFinalizeDistribution(projectDistributions, currentVotes, _balance, _baseSplit, _votedYield);
     }
 
     /**
-     * @notice Distribute $BREAD yield to projects using gas efficient voting system to avoid OOG errors
+     * @notice Distribute $BREAD yield to projects
+     * @dev Claims accrued yield from the BREAD contract, splits it into a fixed equal portion
+     *      and a voted portion, then transfers to each project in proportion to accumulated
+     *      `projectDistributions`. Resets voter state and increments `votingCycle` on success.
+     *      Reverts via `YieldNotResolved` if preconditions (minimum blocks elapsed, votes cast,
+     *      sufficient yield) are not met. The `trackState` modifier applies GasKiller AVS
+     *      task-state tracking for gas-efficient on-chain verification.
      */
     function distributeYield() public trackState {
         (uint256 balance, uint256 _baseSplit, uint256 _votedYield) = _claimAndPrepareYield();
@@ -363,7 +446,13 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
 
     /**
      * @notice Cast votes for the distribution of $BREAD yield
-     * @param _points List of points as integers for each project
+     * @dev Voting power is computed from combined BREAD + ButteredBread balances over the
+     *      previous cycle window (`previousCycleStartingBlock` → `lastClaimedBlockNumber`).
+     *      A voter may re-cast in the same cycle to update their allocation; the previous
+     *      vote is replaced entirely. Points are allocated proportionally across projects.
+     *      Reverts if `_points.length` does not match the current project count, any single
+     *      value exceeds `maxPoints`, or the total is zero.
+     * @param _points Array of relative allocation points for each project (must sum > 0)
      */
     function castVote(uint256[] calldata _points) public trackState {
         uint256 _currentVotingPower = getCurrentVotingPower(msg.sender);
@@ -372,9 +461,16 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
     }
 
     /**
-     * @notice Cast votes for the distribution of $BREAD yield with multipliers
-     * @param _points List of points as integers for each project
-     * @param _multiplierIndices List of indices of multipliers to use for each project
+     * @notice Cast votes for the distribution of $BREAD yield with voting-power multipliers
+     * @dev The caller's base voting power (BREAD + ButteredBread over the previous cycle) is
+     *      scaled by the product of the selected multipliers before being applied to the vote.
+     *      Each multiplier's `updateMultiplyingFactor` is called first to ensure state is fresh
+     *      (e.g. VotingStreakMultiplier increments the streak here). Duplicate indices and
+     *      out-of-range indices are rejected. If the combined multiplier resolves to zero
+     *      (no valid multiplier), the base voting power is used unchanged.
+     * @param _points Array of relative allocation points for each project (must sum > 0)
+     * @param _multiplierIndices Indices into the `allowlistedMultipliers` array; each index
+     *        selects one active multiplier to apply. Must not contain duplicates.
      */
     function castVoteWithMultipliers(uint256[] calldata _points, uint256[] calldata _multiplierIndices)
         public
@@ -599,11 +695,41 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
     }
 
     /**
+     * @notice Set the BREAD token contract address
+     * @dev Allows updating the BREAD token reference without redeploying the contract.
+     *      Should only be used during token migrations or if the BREAD contract is upgraded
+     *      to a new address. Reverts if the new address is zero.
+     * @param _bread Address of the new $BREAD token contract
+     */
+    function setBread(address _bread) public onlyOwner trackState {
+        if (_bread == address(0)) revert MustBeGreaterThanZero();
+        BREAD = IBread(_bread);
+    }
+
+    /**
      * @notice Set the ButteredBread token contract
      * @param _butteredBread Address of the ButteredBread token contract
      */
     function setButteredBread(address _butteredBread) public onlyOwner trackState {
         BUTTERED_BREAD = IERC20Votes(_butteredBread);
+    }
+
+    /**
+     * @notice Returns the full list of eligible member projects
+     * @dev Convenience view function to retrieve the entire projects array in a single call,
+     *      avoiding the need for callers to iterate via the indexed `projects(uint256)` getter.
+     * @return address[] Array of all currently eligible project addresses
+     */
+    function getProjects() external view returns (address[] memory) {
+        return projects;
+    }
+
+    /**
+     * @notice Returns the number of currently eligible member projects
+     * @return uint256 The length of the projects array
+     */
+    function getProjectCount() external view returns (uint256) {
+        return projects.length;
     }
 
     /**

--- a/src/multipliers/BreadBakeCountMultiplier.sol
+++ b/src/multipliers/BreadBakeCountMultiplier.sol
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.22;
+
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+import {IMultiplier} from "src/interfaces/multipliers/IMultiplier.sol";
+import {MultiplierConstants} from "src/libraries/MultiplierConstants.sol";
+
+/// @title Bread Bake Count Multiplier
+/// @notice Grants a voting power boost to BREAD holders who have baked BREAD 10 or more times.
+///
+/// @dev "Baking" refers to calling the BREAD `mint()` function (depositing xDAI to receive BREAD).
+///      Because Solidity cannot count past Minted events on-chain, bake counts are maintained
+///      off-chain by a trusted oracle that monitors the BREAD contract and records when an
+///      address reaches or exceeds the `BAKE_THRESHOLD`.
+///      The oracle calls `grantEligibility(user)` once a user crosses the threshold.
+///      Eligibility cannot be revoked once granted.
+///
+/// Oracle trust model
+/// -------------------
+/// @custom:security-note This contract relies on a single trusted oracle address to grant
+/// eligibility to users who have baked BREAD 10 or more times. This introduces a
+/// centralisation risk:
+///
+/// - SINGLE POINT OF FAILURE: If the oracle key is compromised, an attacker can grant the
+///   multiplier to arbitrary addresses, inflating those addresses' voting power. Conversely,
+///   a negligent or offline oracle may fail to grant eligibility to users who have genuinely
+///   reached the threshold.
+///
+/// - NO ON-CHAIN VERIFICATION: Bake counts are computed off-chain by scanning Minted events.
+///   The contract trusts the oracle's reports without any on-chain proof.
+///
+/// - MITIGATION: In production the oracle address should be a Gnosis Safe multisig (or an
+///   equivalent M-of-N threshold scheme) rather than an externally owned account (EOA).
+///   This distributes the trust and prevents a single key compromise from granting spurious
+///   eligibility. The contract owner retains the ability to call `grantEligibility` and
+///   `grantEligibilityBatch` directly as a fallback, and can rotate the oracle via
+///   `setOracle` if the current one is compromised.
+contract BreadBakeCountMultiplier is Initializable, OwnableUpgradeable, IMultiplier {
+    /// @notice Minimum number of bakes required to earn the multiplier
+    uint256 public constant BAKE_THRESHOLD = 10;
+
+    /// @custom:storage-location erc7201:breadchain.BreadBakeCountMultiplier.storage
+    struct BreadBakeCountMultiplierStorage {
+        /// @notice Multiplying factor for users who have baked 10+ times (fixed-point, 1e18 = 1x)
+        uint256 multiplyingFactor;
+        /// @notice The trusted off-chain verifier that records bake-count eligibility
+        address oracle;
+        /// @notice Tracks users who have reached or exceeded the bake threshold
+        mapping(address => bool) isEligible;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("breadchain.BreadBakeCountMultiplier.storage")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant BREAD_BAKE_COUNT_MULTIPLIER_STORAGE_LOCATION =
+        0x03785cbc7f5634abcf1c8e1fb3ca142488b2f4ec03175d5e34fa9e4032199400;
+
+    function _getBreadBakeCountMultiplierStorage() private pure returns (BreadBakeCountMultiplierStorage storage $) {
+        assembly {
+            $.slot := BREAD_BAKE_COUNT_MULTIPLIER_STORAGE_LOCATION
+        }
+    }
+
+    /// @notice Error emitted when an unauthorized address tries to set eligibility
+    error OnlyOracle();
+    /// @notice Error emitted when an invalid multiplying factor is provided
+    error InvalidMultiplyingFactor();
+    /// @notice Error emitted when a zero oracle address is provided
+    error ZeroOracleAddress();
+
+    /// @notice Emitted when a user becomes eligible (≥10 bakes confirmed)
+    event EligibilityGranted(address indexed user);
+    /// @notice Emitted when the oracle address changes
+    event OracleUpdated(address indexed oldOracle, address indexed newOracle);
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Initializes the contract
+    /// @param _multiplyingFactor Boost factor for qualifying users (>= BASE_MULTIPLIER)
+    /// @param _oracle Address of the trusted off-chain oracle
+    function initialize(uint256 _multiplyingFactor, address _oracle) public initializer {
+        if (_multiplyingFactor < MultiplierConstants.BASE_MULTIPLIER) revert InvalidMultiplyingFactor();
+        if (_oracle == address(0)) revert ZeroOracleAddress();
+
+        __Ownable_init(msg.sender);
+
+        BreadBakeCountMultiplierStorage storage $ = _getBreadBakeCountMultiplierStorage();
+        $.multiplyingFactor = _multiplyingFactor;
+        $.oracle = _oracle;
+    }
+
+    /// @notice Returns the multiplying factor if the user has baked 10+ times
+    /// @param _user The address of the user
+    /// @return The multiplyingFactor if eligible, 0 otherwise
+    function getMultiplyingFactor(address _user) external view override returns (uint256) {
+        BreadBakeCountMultiplierStorage storage $ = _getBreadBakeCountMultiplierStorage();
+        return $.isEligible[_user] ? $.multiplyingFactor : 0;
+    }
+
+    /// @notice Once granted, bake-count eligibility never expires.
+    function validUntil(address /* _user */ ) external pure override returns (uint256) {
+        return type(uint256).max;
+    }
+
+    /// @notice No op — eligibility is set by the oracle, not computed lazily.
+    function updateMultiplyingFactor(address /* _user */ ) external pure override {
+        return;
+    }
+
+    // ───────────────────────── Oracle ─────────────────────────
+
+    /// @notice Grant the multiplier to a user who has reached 10+ bakes
+    /// @dev Called by the oracle when it detects a user's bake count crosses BAKE_THRESHOLD.
+    /// @param _user The address to grant eligibility to
+    function grantEligibility(address _user) external {
+        BreadBakeCountMultiplierStorage storage $ = _getBreadBakeCountMultiplierStorage();
+        if (msg.sender != $.oracle && msg.sender != owner()) revert OnlyOracle();
+        if (!$.isEligible[_user]) {
+            $.isEligible[_user] = true;
+            emit EligibilityGranted(_user);
+        }
+    }
+
+    /// @notice Batch-grant eligibility to multiple users
+    /// @param _users Array of user addresses to grant eligibility to
+    function grantEligibilityBatch(address[] calldata _users) external {
+        BreadBakeCountMultiplierStorage storage $ = _getBreadBakeCountMultiplierStorage();
+        if (msg.sender != $.oracle && msg.sender != owner()) revert OnlyOracle();
+        for (uint256 i = 0; i < _users.length; i++) {
+            if (!$.isEligible[_users[i]]) {
+                $.isEligible[_users[i]] = true;
+                emit EligibilityGranted(_users[i]);
+            }
+        }
+    }
+
+    // ───────────────────────── Admin ─────────────────────────
+
+    /// @notice Update the oracle address
+    /// @param _oracle New oracle address (must be non-zero)
+    function setOracle(address _oracle) external onlyOwner {
+        if (_oracle == address(0)) revert ZeroOracleAddress();
+        BreadBakeCountMultiplierStorage storage $ = _getBreadBakeCountMultiplierStorage();
+        emit OracleUpdated($.oracle, _oracle);
+        $.oracle = _oracle;
+    }
+
+    /// @notice Update the multiplying factor applied to qualifying bakers
+    /// @param _multiplyingFactor New multiplier (must be >= BASE_MULTIPLIER, i.e. 1e18)
+    function setMultiplyingFactor(uint256 _multiplyingFactor) external onlyOwner {
+        if (_multiplyingFactor < MultiplierConstants.BASE_MULTIPLIER) revert InvalidMultiplyingFactor();
+        _getBreadBakeCountMultiplierStorage().multiplyingFactor = _multiplyingFactor;
+    }
+
+    // ───────────────────────── Public getters ─────────────────────────
+
+    /// @notice Multiplying factor for users who have baked 10+ times
+    function multiplyingFactor() external view returns (uint256) {
+        return _getBreadBakeCountMultiplierStorage().multiplyingFactor;
+    }
+
+    /// @notice The trusted off-chain verifier that records bake-count eligibility
+    function oracle() external view returns (address) {
+        return _getBreadBakeCountMultiplierStorage().oracle;
+    }
+
+    /// @notice Tracks users who have reached or exceeded the bake threshold
+    function isEligible(address user) external view returns (bool) {
+        return _getBreadBakeCountMultiplierStorage().isEligible[user];
+    }
+}

--- a/src/multipliers/BreadTransactionMultiplier.sol
+++ b/src/multipliers/BreadTransactionMultiplier.sol
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.22;
+
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {Checkpoints} from "@openzeppelin/contracts/utils/structs/Checkpoints.sol";
+
+import {IMultiplier} from "src/interfaces/multipliers/IMultiplier.sol";
+import {IERC20Votes} from "src/interfaces/IERC20Votes.sol";
+import {MultiplierConstants} from "src/libraries/MultiplierConstants.sol";
+
+/// @title Bread Transaction Multiplier
+/// @notice Grants a voting power boost to users who have made BREAD token transactions
+///         within a qualifying window of blocks.
+/// @dev Uses the ERC20Votes checkpoint history of the BREAD token to verify activity.
+///      A checkpoint is created whenever a user's delegated-vote balance changes
+///      (i.e. on any transfer from/to an account that has self-delegated). This is a
+///      reliable on-chain signal that the user is actively transacting in BREAD.
+contract BreadTransactionMultiplier is Initializable, OwnableUpgradeable, IMultiplier {
+    /// @custom:storage-location erc7201:breadchain.BreadTransactionMultiplier.storage
+    struct BreadTransactionMultiplierStorage {
+        /// @notice The BREAD token contract (must implement IERC20Votes)
+        IERC20Votes breadToken;
+        /// @notice Multiplying factor granted to qualifying users (fixed-point, 1e18 = 1x)
+        uint256 multiplyingFactor;
+        /// @notice Number of blocks that define the qualifying activity window.
+        ///         A user qualifies if their most recent BREAD checkpoint falls within
+        ///         the last `qualifyingWindow` blocks.
+        uint256 qualifyingWindow;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("breadchain.BreadTransactionMultiplier.storage")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant BREAD_TRANSACTION_MULTIPLIER_STORAGE_LOCATION =
+        0xe2e42077bd75363d8940e45df66a43416e57f9d9e336cd68df4a57e6c2adb300;
+
+    function _getBreadTransactionMultiplierStorage()
+        private
+        pure
+        returns (BreadTransactionMultiplierStorage storage $)
+    {
+        assembly {
+            $.slot := BREAD_TRANSACTION_MULTIPLIER_STORAGE_LOCATION
+        }
+    }
+
+    /// @notice Error emitted when an invalid qualifying window is provided
+    error InvalidQualifyingWindow();
+
+    /// @notice Error emitted when an invalid multiplying factor is provided
+    error InvalidMultiplyingFactor();
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Initializes the contract
+    /// @param _breadToken Address of the BREAD token (must implement IERC20Votes)
+    /// @param _multiplyingFactor The multiplying factor for active BREAD users (fixed-point 1e18 = 1x)
+    /// @param _qualifyingWindow Number of blocks in which activity must have occurred
+    function initialize(address _breadToken, uint256 _multiplyingFactor, uint256 _qualifyingWindow)
+        public
+        initializer
+    {
+        if (_multiplyingFactor < MultiplierConstants.BASE_MULTIPLIER) revert InvalidMultiplyingFactor();
+        if (_qualifyingWindow == 0) revert InvalidQualifyingWindow();
+
+        __Ownable_init(msg.sender);
+
+        BreadTransactionMultiplierStorage storage $ = _getBreadTransactionMultiplierStorage();
+        $.breadToken = IERC20Votes(_breadToken);
+        $.multiplyingFactor = _multiplyingFactor;
+        $.qualifyingWindow = _qualifyingWindow;
+    }
+
+    /// @notice Returns the multiplying factor if the user has been active within the qualifying window
+    /// @dev Walks the user's BREAD vote checkpoints backwards to find a recent one.
+    ///      A checkpoint is created when a delegated balance changes (transfer, mint, burn),
+    ///      so this is a faithful proxy for BREAD transaction activity.
+    /// @param _user The address of the user to check
+    /// @return The multiplyingFactor if active, 0 otherwise
+    function getMultiplyingFactor(address _user) public view override returns (uint256) {
+        BreadTransactionMultiplierStorage storage $ = _getBreadTransactionMultiplierStorage();
+        uint32 numCheckpoints = $.breadToken.numCheckpoints(_user);
+        if (numCheckpoints == 0) return 0;
+
+        uint256 windowStart = block.number > $.qualifyingWindow ? block.number - $.qualifyingWindow : 0;
+
+        // Walk backwards from most recent checkpoint to find activity within the window.
+        // In practice the most recent checkpoint is almost always within the window,
+        // so this is O(1) in the common case.
+        for (uint32 i = numCheckpoints; i > 0;) {
+            Checkpoints.Checkpoint208 memory cp = $.breadToken.checkpoints(_user, --i);
+            if (cp._key >= windowStart) {
+                return $.multiplyingFactor;
+            }
+            // Checkpoints are stored in ascending order; if this one is already before
+            // the window, all earlier ones will be too — stop early.
+            break;
+        }
+
+        return 0;
+    }
+
+    /// @notice The multiplier check is always live; returns type(uint256).max so the
+    ///         VotingMultipliers router never gates on block validity.
+    function validUntil(address /* _user */ ) external pure override returns (uint256) {
+        return type(uint256).max;
+    }
+
+    /// @notice No persistent state to update; the check is computed fresh each call.
+    function updateMultiplyingFactor(address /* _user */ ) external pure override {
+        return;
+    }
+
+    // ───────────────────────── Admin ─────────────────────────
+
+    /// @notice Update the qualifying activity window
+    /// @param _qualifyingWindow New window size in blocks
+    function setQualifyingWindow(uint256 _qualifyingWindow) external onlyOwner {
+        if (_qualifyingWindow == 0) revert InvalidQualifyingWindow();
+        _getBreadTransactionMultiplierStorage().qualifyingWindow = _qualifyingWindow;
+    }
+
+    /// @notice Update the multiplying factor
+    /// @param _multiplyingFactor New factor (must be >= BASE_MULTIPLIER)
+    function setMultiplyingFactor(uint256 _multiplyingFactor) external onlyOwner {
+        if (_multiplyingFactor < MultiplierConstants.BASE_MULTIPLIER) revert InvalidMultiplyingFactor();
+        _getBreadTransactionMultiplierStorage().multiplyingFactor = _multiplyingFactor;
+    }
+
+    /// @notice Update the BREAD token address used for checkpoint lookups
+    /// @param _breadToken New BREAD token address (must implement IERC20Votes)
+    function setBreadToken(address _breadToken) external onlyOwner {
+        _getBreadTransactionMultiplierStorage().breadToken = IERC20Votes(_breadToken);
+    }
+
+    // ───────────────────────── Public getters ─────────────────────────
+
+    /// @notice The BREAD token contract
+    function breadToken() external view returns (IERC20Votes) {
+        return _getBreadTransactionMultiplierStorage().breadToken;
+    }
+
+    /// @notice Multiplying factor granted to qualifying users
+    function multiplyingFactor() external view returns (uint256) {
+        return _getBreadTransactionMultiplierStorage().multiplyingFactor;
+    }
+
+    /// @notice Number of blocks that define the qualifying activity window
+    function qualifyingWindow() external view returns (uint256) {
+        return _getBreadTransactionMultiplierStorage().qualifyingWindow;
+    }
+}

--- a/src/multipliers/NFTMultiplier.sol
+++ b/src/multipliers/NFTMultiplier.sol
@@ -11,9 +11,22 @@ import {INFTMultiplier} from "src/interfaces/multipliers/INFTMultiplier.sol";
 /// @notice Implementation of INFTMultiplier interface
 /// @dev Provides multiplying factors based on NFT ownership
 contract NFTMultiplier is INFTMultiplier, Initializable, Ownable2StepUpgradeable {
-    IERC721 public nftContract;
-    uint256 public multiplyingFactor;
-    uint256 public validUntilBlock;
+    /// @custom:storage-location erc7201:breadchain.NFTMultiplier.storage
+    struct NFTMultiplierStorage {
+        IERC721 nftContract;
+        uint256 multiplyingFactor;
+        uint256 validUntilBlock;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("breadchain.NFTMultiplier.storage")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant NFT_MULTIPLIER_STORAGE_LOCATION =
+        0xe45930265d610c1320a62a84e596c0558c92bf6866e1e070a054adb48c3e6600;
+
+    function _getNFTMultiplierStorage() private pure returns (NFTMultiplierStorage storage $) {
+        assembly {
+            $.slot := NFT_MULTIPLIER_STORAGE_LOCATION
+        }
+    }
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -30,29 +43,30 @@ contract NFTMultiplier is INFTMultiplier, Initializable, Ownable2StepUpgradeable
     {
         __Ownable_init(msg.sender);
 
-        nftContract = _nftContract;
-        multiplyingFactor = _initialMultiplyingFactor;
-        validUntilBlock = _validUntilBlock;
+        NFTMultiplierStorage storage $ = _getNFTMultiplierStorage();
+        $.nftContract = _nftContract;
+        $.multiplyingFactor = _initialMultiplyingFactor;
+        $.validUntilBlock = _validUntilBlock;
     }
 
     /// @notice Get the address of the NFT contract
     /// @return The address of the NFT contract used for checking ownership
     function NFT_ADDRESS() external view override returns (IERC721) {
-        return nftContract;
+        return _getNFTMultiplierStorage().nftContract;
     }
 
     /// @notice Check if a _user owns an NFT
     /// @param _user The address of the _user to check
     /// @return True if the _user owns at least one NFT, false otherwise
     function hasNFT(address _user) public view override returns (bool) {
-        return nftContract.balanceOf(_user) > 0;
+        return _getNFTMultiplierStorage().nftContract.balanceOf(_user) > 0;
     }
 
     /// @notice Get the multiplying factor for a given _user
     /// @param _user The address of the _user
     /// @return The multiplying factor if the _user owns an NFT, 0 otherwise
     function getMultiplyingFactor(address _user) external view override returns (uint256) {
-        return hasNFT(_user) ? multiplyingFactor : 0;
+        return hasNFT(_user) ? _getNFTMultiplierStorage().multiplyingFactor : 0;
     }
 
     /// @notice Get the block number until which the multiplier is valid
@@ -65,10 +79,11 @@ contract NFTMultiplier is INFTMultiplier, Initializable, Ownable2StepUpgradeable
         override
         returns (uint256)
     {
-        return validUntilBlock;
+        return _getNFTMultiplierStorage().validUntilBlock;
     }
 
-    /// @notice Updates the multiplying factor for a specific user
+    /// @notice No-op: NFT ownership is checked live; no per-user state to update
+    /// @dev Required by the IMultiplier interface. Calling this has no effect.
     function updateMultiplyingFactor(
         address /* _user */
     )
@@ -81,12 +96,29 @@ contract NFTMultiplier is INFTMultiplier, Initializable, Ownable2StepUpgradeable
     /// @notice Update the valid until block
     /// @param _newValidUntilBlock New block number until which the multiplier is valid
     function updateValidUntilBlock(uint256 _newValidUntilBlock) external onlyOwner {
-        validUntilBlock = _newValidUntilBlock;
+        _getNFTMultiplierStorage().validUntilBlock = _newValidUntilBlock;
     }
 
     /// @notice Update the NFT contract address
     /// @param _newNFTContract New NFT contract address
     function updateNFTContract(IERC721 _newNFTContract) external onlyOwner {
-        nftContract = _newNFTContract;
+        _getNFTMultiplierStorage().nftContract = _newNFTContract;
+    }
+
+    // ───────────────────────── Public getters ─────────────────────────
+
+    /// @notice The NFT contract
+    function nftContract() external view returns (IERC721) {
+        return _getNFTMultiplierStorage().nftContract;
+    }
+
+    /// @notice The multiplying factor
+    function multiplyingFactor() external view returns (uint256) {
+        return _getNFTMultiplierStorage().multiplyingFactor;
+    }
+
+    /// @notice The block until which the multiplier is valid
+    function validUntilBlock() external view returns (uint256) {
+        return _getNFTMultiplierStorage().validUntilBlock;
     }
 }

--- a/src/multipliers/NeverBurnedBreadMultiplier.sol
+++ b/src/multipliers/NeverBurnedBreadMultiplier.sol
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.22;
+
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+import {IMultiplier} from "src/interfaces/multipliers/IMultiplier.sol";
+import {MultiplierConstants} from "src/libraries/MultiplierConstants.sol";
+
+/// @title Never Burned Bread Multiplier
+/// @notice Grants a voting power boost to BREAD holders who have never burned BREAD tokens.
+///
+/// @dev Burning BREAD emits a Transfer event from the holder to address(0). Because Solidity
+///      cannot scan past events on-chain, eligibility is maintained off-chain by a trusted
+///      verifier (the `oracle` address) that monitors the BREAD contract for Burned events and
+///      revokes eligibility by calling `recordBurn(user)`.
+///      New users are considered eligible by default (no burn ≡ eligible). Once revoked,
+///      eligibility cannot be restored — the burn record is permanent.
+///
+/// Oracle trust model
+/// -------------------
+/// @custom:security-note This contract relies on a single trusted oracle address to record
+/// whether a user has burned BREAD. This introduces a centralisation risk:
+///
+/// - SINGLE POINT OF FAILURE: If the oracle key is compromised, an attacker can permanently
+///   revoke the multiplier for arbitrary users (denial-of-service), or if the oracle is
+///   negligent it may fail to record burns (false positives — users retain the multiplier
+///   after burning).
+///
+/// - NO ON-CHAIN VERIFICATION: The oracle's attestations cannot be independently verified
+///   on-chain. The contract trusts whatever the oracle reports.
+///
+/// - MITIGATION: In production the oracle address should be a Gnosis Safe multisig (or an
+///   equivalent M-of-N threshold scheme) rather than an externally owned account (EOA).
+///   This distributes the trust and prevents a single key compromise from affecting users.
+///   The contract owner retains the ability to call `recordBurn` and `recordBurns` directly
+///   as a fallback, and can rotate the oracle via `setOracle` if the current one is compromised.
+contract NeverBurnedBreadMultiplier is Initializable, OwnableUpgradeable, IMultiplier {
+    /// @custom:storage-location erc7201:breadchain.NeverBurnedBreadMultiplier.storage
+    struct NeverBurnedBreadMultiplierStorage {
+        /// @notice Multiplying factor for users who have never burned BREAD (fixed-point, 1e18 = 1x)
+        uint256 multiplyingFactor;
+        /// @notice The trusted off-chain verifier that can revoke eligibility
+        address oracle;
+        /// @notice Tracks users whose eligibility has been explicitly revoked (burned BREAD)
+        /// @dev Absence from this mapping means the user has never burned (eligible).
+        mapping(address => bool) hasBurned;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("breadchain.NeverBurnedBreadMultiplier.storage")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant NEVER_BURNED_BREAD_MULTIPLIER_STORAGE_LOCATION =
+        0xc351da930d721e83a504690036fa250f9bd0d16b0ba735ba19fd902d1d497c00;
+
+    function _getNeverBurnedBreadMultiplierStorage()
+        private
+        pure
+        returns (NeverBurnedBreadMultiplierStorage storage $)
+    {
+        assembly {
+            $.slot := NEVER_BURNED_BREAD_MULTIPLIER_STORAGE_LOCATION
+        }
+    }
+
+    /// @notice Error emitted when an unauthorized address tries to revoke eligibility
+    error OnlyOracle();
+    /// @notice Error emitted when an invalid multiplying factor is provided
+    error InvalidMultiplyingFactor();
+    /// @notice Error emitted when a zero oracle address is provided
+    error ZeroOracleAddress();
+
+    /// @notice Emitted when a user's burn status is recorded
+    event BurnStatusRecorded(address indexed user, bool burned);
+    /// @notice Emitted when the oracle address changes
+    event OracleUpdated(address indexed oldOracle, address indexed newOracle);
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Initializes the contract
+    /// @param _multiplyingFactor Boost factor for never-burned users (>= BASE_MULTIPLIER)
+    /// @param _oracle Address of the trusted off-chain oracle that records burns
+    function initialize(uint256 _multiplyingFactor, address _oracle) public initializer {
+        if (_multiplyingFactor < MultiplierConstants.BASE_MULTIPLIER) revert InvalidMultiplyingFactor();
+        if (_oracle == address(0)) revert ZeroOracleAddress();
+
+        __Ownable_init(msg.sender);
+
+        NeverBurnedBreadMultiplierStorage storage $ = _getNeverBurnedBreadMultiplierStorage();
+        $.multiplyingFactor = _multiplyingFactor;
+        $.oracle = _oracle;
+    }
+
+    /// @notice Returns the multiplying factor if the user has never burned BREAD
+    /// @param _user The address of the user
+    /// @return The multiplyingFactor if not burned, 0 otherwise
+    function getMultiplyingFactor(address _user) external view override returns (uint256) {
+        NeverBurnedBreadMultiplierStorage storage $ = _getNeverBurnedBreadMultiplierStorage();
+        return $.hasBurned[_user] ? 0 : $.multiplyingFactor;
+    }
+
+    /// @notice The multiplier is permanent once granted; validity is tracked via hasBurned.
+    function validUntil(address /* _user */ ) external pure override returns (uint256) {
+        return type(uint256).max;
+    }
+
+    /// @notice No op — eligibility is managed by the oracle, not lazily updated on-chain.
+    function updateMultiplyingFactor(address /* _user */ ) external pure override {
+        return;
+    }
+
+    // ───────────────────────── Oracle ─────────────────────────
+
+    /// @notice Record that a user has burned BREAD (revokes their multiplier permanently)
+    /// @dev Called by the off-chain oracle when a Burned event is detected on the BREAD contract.
+    ///      The owner may also call this directly for manual corrections.
+    /// @param _user The address of the user who burned BREAD
+    function recordBurn(address _user) external {
+        NeverBurnedBreadMultiplierStorage storage $ = _getNeverBurnedBreadMultiplierStorage();
+        if (msg.sender != $.oracle && msg.sender != owner()) revert OnlyOracle();
+        if (!$.hasBurned[_user]) {
+            $.hasBurned[_user] = true;
+            emit BurnStatusRecorded(_user, true);
+        }
+    }
+
+    /// @notice Batch-record burns for multiple users
+    /// @param _users Array of user addresses who have burned BREAD
+    function recordBurns(address[] calldata _users) external {
+        NeverBurnedBreadMultiplierStorage storage $ = _getNeverBurnedBreadMultiplierStorage();
+        if (msg.sender != $.oracle && msg.sender != owner()) revert OnlyOracle();
+        for (uint256 i = 0; i < _users.length; i++) {
+            if (!$.hasBurned[_users[i]]) {
+                $.hasBurned[_users[i]] = true;
+                emit BurnStatusRecorded(_users[i], true);
+            }
+        }
+    }
+
+    // ───────────────────────── Admin ─────────────────────────
+
+    /// @notice Update the oracle address
+    /// @param _oracle New oracle address (must be non-zero)
+    function setOracle(address _oracle) external onlyOwner {
+        if (_oracle == address(0)) revert ZeroOracleAddress();
+        NeverBurnedBreadMultiplierStorage storage $ = _getNeverBurnedBreadMultiplierStorage();
+        emit OracleUpdated($.oracle, _oracle);
+        $.oracle = _oracle;
+    }
+
+    /// @notice Update the multiplying factor applied to users who have never burned BREAD
+    /// @param _multiplyingFactor New multiplier (must be >= BASE_MULTIPLIER, i.e. 1e18)
+    function setMultiplyingFactor(uint256 _multiplyingFactor) external onlyOwner {
+        if (_multiplyingFactor < MultiplierConstants.BASE_MULTIPLIER) revert InvalidMultiplyingFactor();
+        _getNeverBurnedBreadMultiplierStorage().multiplyingFactor = _multiplyingFactor;
+    }
+
+    // ───────────────────────── Public getters ─────────────────────────
+
+    /// @notice Multiplying factor for users who have never burned BREAD
+    function multiplyingFactor() external view returns (uint256) {
+        return _getNeverBurnedBreadMultiplierStorage().multiplyingFactor;
+    }
+
+    /// @notice The trusted off-chain verifier that can revoke eligibility
+    function oracle() external view returns (address) {
+        return _getNeverBurnedBreadMultiplierStorage().oracle;
+    }
+
+    /// @notice Tracks users whose eligibility has been explicitly revoked (burned BREAD)
+    function hasBurned(address user) external view returns (bool) {
+        return _getNeverBurnedBreadMultiplierStorage().hasBurned[user];
+    }
+}

--- a/src/multipliers/POAPMultiplier.sol
+++ b/src/multipliers/POAPMultiplier.sol
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.22;
+
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+import {IMultiplier} from "src/interfaces/multipliers/IMultiplier.sol";
+import {MultiplierConstants} from "src/libraries/MultiplierConstants.sol";
+
+/// @title POAP Multiplier
+/// @notice Grants a voting power boost to users who hold a qualifying POAP
+///         (Proof of Attendance Protocol) token from approved events.
+///
+/// @dev The POAP ERC-721 contract on Gnosis Chain is at 0x22C1f6050E56d2876009903609a2cC3fEf83B415.
+///
+/// On-chain event-ID enumeration limitation
+/// -----------------------------------------
+/// The POAP ERC-721 token encodes an event ID per token. The POAP contract exposes a
+/// non-standard helper `tokenDetailsOfOwnerByIndex(address owner, uint256 index)`
+/// that returns `(uint256 eventId, uint256 tokenId)`. However, calling this in a view
+/// function to iterate over all of a user's tokens is unbounded (O(n) per user, where
+/// n is the number of tokens held) and is not guaranteed to be available on every
+/// deployment or fork of the POAP contract.
+///
+/// Oracle-assisted event-ID enforcement
+/// --------------------------------------
+/// When `acceptAnyPoap = false` and qualifying event IDs are configured, pure on-chain
+/// enforcement requires iterating token ownership — which is not feasible for arbitrary
+/// holders. Therefore this contract follows the same oracle-assisted pattern as
+/// BreadBakeCountMultiplier and NeverBurnedBreadMultiplier:
+///
+/// - A trusted off-chain oracle (or the contract owner) monitors POAP token transfers
+///   on-chain, looks up the event ID of each relevant token via `tokenDetailsOfOwnerByIndex`
+///   or the Gnosis Chain POAP subgraph, and calls `attestQualifyingHolder` (or the
+///   batch variant) to record that an address holds a POAP from a qualifying event.
+/// - Attesetd eligibility is stored in `isAttested[user]` and is revocable by the oracle
+///   or owner if the user later transfers away their qualifying POAP.
+///
+/// Trust model and risks
+/// ----------------------
+/// @custom:security-note The oracle is a single point of trust. If the oracle key is
+/// compromised, the attacker can grant the multiplier to arbitrary addresses. For
+/// production deployments, the oracle should be a multisig (e.g. a Gnosis Safe) or
+/// a decentralised keeper network to reduce this risk. The contract owner can always
+/// override the oracle by calling the attest/revoke functions directly.
+///
+/// Modes of operation
+/// -------------------
+/// 1. `acceptAnyPoap = true` — Any POAP holder qualifies; no event-ID check, no oracle needed.
+/// 2. `acceptAnyPoap = false` with empty `qualifyingEventIds` — No one qualifies; acts as a pause.
+/// 3. `acceptAnyPoap = false` with event IDs configured — Only oracle-attested holders qualify.
+///    The oracle should monitor qualifying events and call `attestQualifyingHolder`.
+contract POAPMultiplier is Initializable, Ownable2StepUpgradeable, IMultiplier {
+    /// @custom:storage-location erc7201:breadchain.POAPMultiplier.storage
+    struct POAPMultiplierStorage {
+        /// @notice The POAP ERC-721 contract
+        IERC721 poapContract;
+        /// @notice Multiplying factor granted to POAP holders (fixed-point, 1e18 = 1x)
+        uint256 multiplyingFactor;
+        /// @notice If true, any POAP qualifies (event ID check is skipped).
+        ///         Set by the owner to simplify integration before event IDs are known.
+        bool acceptAnyPoap;
+        /// @notice Allowlisted POAP event IDs whose holders qualify
+        /// @dev Iterable list; also mirrored in a mapping for O(1) lookup
+        uint256[] qualifyingEventIds;
+        /// @notice O(1) lookup: event ID → whether it's approved
+        mapping(uint256 => bool) isQualifyingEventId;
+        /// @notice The trusted off-chain oracle that attests qualifying POAP holders.
+        ///
+        /// @dev The oracle monitors POAP token transfers on-chain and checks whether a holder
+        ///      owns a token whose event ID appears in `qualifyingEventIds`. When confirmed, the
+        ///      oracle calls `attestQualifyingHolder`. The oracle should be a multisig in production.
+        ///
+        /// @custom:security-note This is a single point of trust. See the contract-level NatSpec
+        ///      for a full discussion of the trust model and mitigation recommendations.
+        address oracle;
+        /// @notice Records addresses that have been attested by the oracle as holding a
+        ///         qualifying POAP. Used only when `acceptAnyPoap = false`.
+        mapping(address => bool) isAttested;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("breadchain.POAPMultiplier.storage")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant POAP_MULTIPLIER_STORAGE_LOCATION =
+        0xb7a828628f9ae0dcaafc87f9e42c18b49ad328afdbfda7bf94e7ef79814d1100;
+
+    function _getPOAPMultiplierStorage() private pure returns (POAPMultiplierStorage storage $) {
+        assembly {
+            $.slot := POAP_MULTIPLIER_STORAGE_LOCATION
+        }
+    }
+
+    /// @notice Error emitted when trying to add a duplicate event ID
+    error EventIdAlreadyAllowlisted(uint256 eventId);
+    /// @notice Error emitted when trying to remove a non-existent event ID
+    error EventIdNotAllowlisted(uint256 eventId);
+    /// @notice Error emitted when an invalid multiplying factor is provided
+    error InvalidMultiplyingFactor();
+    /// @notice Error emitted when an unauthorized address tries to attest/revoke
+    error OnlyOracle();
+    /// @notice Error emitted when a zero oracle address is provided
+    error ZeroOracleAddress();
+
+    /// @notice Emitted when a POAP event ID is added to the allowlist
+    event EventIdAdded(uint256 indexed eventId);
+    /// @notice Emitted when a POAP event ID is removed from the allowlist
+    event EventIdRemoved(uint256 indexed eventId);
+    /// @notice Emitted when an address is attested as holding a qualifying POAP
+    event HolderAttested(address indexed user);
+    /// @notice Emitted when an attestation is revoked (user no longer holds a qualifying POAP)
+    event AttestationRevoked(address indexed user);
+    /// @notice Emitted when the oracle address changes
+    event OracleUpdated(address indexed oldOracle, address indexed newOracle);
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Initializes the contract
+    /// @param _poapContract Address of the POAP ERC-721 contract
+    /// @param _multiplyingFactor Boost factor for POAP holders (>= BASE_MULTIPLIER)
+    /// @param _acceptAnyPoap If true, any POAP token qualifies regardless of event ID
+    /// @param _initialEventIds Initial list of qualifying POAP event IDs
+    /// @param _oracle Address of the trusted off-chain oracle (may be address(0) when
+    ///        acceptAnyPoap=true, but must be non-zero if event-ID filtering is intended)
+    function initialize(
+        IERC721 _poapContract,
+        uint256 _multiplyingFactor,
+        bool _acceptAnyPoap,
+        uint256[] calldata _initialEventIds,
+        address _oracle
+    ) public initializer {
+        if (_multiplyingFactor < MultiplierConstants.BASE_MULTIPLIER) revert InvalidMultiplyingFactor();
+
+        __Ownable2Step_init();
+        _transferOwnership(msg.sender);
+
+        POAPMultiplierStorage storage $ = _getPOAPMultiplierStorage();
+        $.poapContract = _poapContract;
+        $.multiplyingFactor = _multiplyingFactor;
+        $.acceptAnyPoap = _acceptAnyPoap;
+        $.oracle = _oracle;
+
+        for (uint256 i = 0; i < _initialEventIds.length; i++) {
+            _addEventId(_initialEventIds[i]);
+        }
+    }
+
+    /// @notice Returns the multiplying factor if the user holds a qualifying POAP
+    ///
+    /// Logic:
+    ///  - If the user holds no POAP at all → 0
+    ///  - If `acceptAnyPoap = true` → multiplyingFactor (any POAP holder qualifies)
+    ///  - If `acceptAnyPoap = false` and no event IDs configured → 0 (paused state)
+    ///  - If `acceptAnyPoap = false` and event IDs are configured → only oracle-attested
+    ///    holders qualify (`isAttested[_user]` must be true)
+    ///
+    /// @param _user The address of the user
+    /// @return The multiplyingFactor if the user holds a qualifying POAP, 0 otherwise
+    function getMultiplyingFactor(address _user) external view override returns (uint256) {
+        POAPMultiplierStorage storage $ = _getPOAPMultiplierStorage();
+
+        // Fast exit: no POAP at all
+        if ($.poapContract.balanceOf(_user) == 0) return 0;
+
+        // Mode 1: accept any POAP
+        if ($.acceptAnyPoap) return $.multiplyingFactor;
+
+        // Mode 2: paused — no qualifying events configured
+        if ($.qualifyingEventIds.length == 0) return 0;
+
+        // Mode 3: event-ID filtered — require oracle attestation.
+        // On-chain enumeration of which event a specific POAP token belongs to is not
+        // feasible in a general way (the POAP ERC-721 standard does not extend
+        // ERC721Enumerable, and the `tokenDetailsOfOwnerByIndex` helper is not available
+        // on all deployments). The trusted oracle must attest qualifying holders off-chain.
+        return $.isAttested[_user] ? $.multiplyingFactor : 0;
+    }
+
+    /// @notice The multiplier is always live; validity is managed per user's POAP holding.
+    function validUntil(address /* _user */ ) external pure override returns (uint256) {
+        return type(uint256).max;
+    }
+
+    /// @notice No state to update; computed fresh each call.
+    function updateMultiplyingFactor(address /* _user */ ) external pure override {
+        return;
+    }
+
+    // ───────────────────────── Oracle ─────────────────────────
+
+    /// @notice Attest that a user holds a POAP from one of the qualifying events.
+    ///
+    /// @dev Called by the off-chain oracle after confirming (e.g. via the Gnosis Chain
+    ///      POAP subgraph or `tokenDetailsOfOwnerByIndex`) that the user owns a token
+    ///      whose event ID is in `qualifyingEventIds`. The oracle should also monitor
+    ///      Transfer events to revoke attestations when the qualifying POAP is transferred.
+    ///
+    /// @param _user The address to attest
+    function attestQualifyingHolder(address _user) external {
+        POAPMultiplierStorage storage $ = _getPOAPMultiplierStorage();
+        if (msg.sender != $.oracle && msg.sender != owner()) revert OnlyOracle();
+        if (!$.isAttested[_user]) {
+            $.isAttested[_user] = true;
+            emit HolderAttested(_user);
+        }
+    }
+
+    /// @notice Batch-attest multiple qualifying holders
+    /// @param _users Array of user addresses to attest
+    function attestQualifyingHolderBatch(address[] calldata _users) external {
+        POAPMultiplierStorage storage $ = _getPOAPMultiplierStorage();
+        if (msg.sender != $.oracle && msg.sender != owner()) revert OnlyOracle();
+        for (uint256 i = 0; i < _users.length; i++) {
+            if (!$.isAttested[_users[i]]) {
+                $.isAttested[_users[i]] = true;
+                emit HolderAttested(_users[i]);
+            }
+        }
+    }
+
+    /// @notice Revoke an attestation (e.g. user transferred their qualifying POAP away)
+    ///
+    /// @dev The oracle should monitor Transfer events on the POAP contract and call this
+    ///      function when a previously-attested holder no longer owns a qualifying token.
+    ///
+    /// @param _user The address whose attestation should be revoked
+    function revokeAttestation(address _user) external {
+        POAPMultiplierStorage storage $ = _getPOAPMultiplierStorage();
+        if (msg.sender != $.oracle && msg.sender != owner()) revert OnlyOracle();
+        if ($.isAttested[_user]) {
+            $.isAttested[_user] = false;
+            emit AttestationRevoked(_user);
+        }
+    }
+
+    /// @notice Batch-revoke attestations
+    /// @param _users Array of user addresses to revoke
+    function revokeAttestationBatch(address[] calldata _users) external {
+        POAPMultiplierStorage storage $ = _getPOAPMultiplierStorage();
+        if (msg.sender != $.oracle && msg.sender != owner()) revert OnlyOracle();
+        for (uint256 i = 0; i < _users.length; i++) {
+            if ($.isAttested[_users[i]]) {
+                $.isAttested[_users[i]] = false;
+                emit AttestationRevoked(_users[i]);
+            }
+        }
+    }
+
+    // ───────────────────────── Admin ─────────────────────────
+
+    /// @notice Add a qualifying POAP event ID
+    /// @param _eventId The POAP event ID to approve
+    function addEventId(uint256 _eventId) external onlyOwner {
+        _addEventId(_eventId);
+    }
+
+    /// @notice Remove a qualifying POAP event ID
+    /// @param _eventId The POAP event ID to remove
+    function removeEventId(uint256 _eventId) external onlyOwner {
+        POAPMultiplierStorage storage $ = _getPOAPMultiplierStorage();
+        if (!$.isQualifyingEventId[_eventId]) revert EventIdNotAllowlisted(_eventId);
+        $.isQualifyingEventId[_eventId] = false;
+
+        // Swap-and-pop removal
+        for (uint256 i = 0; i < $.qualifyingEventIds.length; i++) {
+            if ($.qualifyingEventIds[i] == _eventId) {
+                $.qualifyingEventIds[i] = $.qualifyingEventIds[$.qualifyingEventIds.length - 1];
+                $.qualifyingEventIds.pop();
+                break;
+            }
+        }
+        emit EventIdRemoved(_eventId);
+    }
+
+    /// @notice Set whether any POAP qualifies (overrides event ID list)
+    /// @param _acceptAnyPoap If true, any POAP token holder qualifies regardless of event ID
+    function setAcceptAnyPoap(bool _acceptAnyPoap) external onlyOwner {
+        _getPOAPMultiplierStorage().acceptAnyPoap = _acceptAnyPoap;
+    }
+
+    /// @notice Update the oracle address
+    /// @param _oracle New oracle address (use address(0) only if acceptAnyPoap=true)
+    function setOracle(address _oracle) external onlyOwner {
+        POAPMultiplierStorage storage $ = _getPOAPMultiplierStorage();
+        emit OracleUpdated($.oracle, _oracle);
+        $.oracle = _oracle;
+    }
+
+    /// @notice Update the multiplying factor applied to qualifying POAP holders
+    /// @param _multiplyingFactor New multiplier (must be >= BASE_MULTIPLIER, i.e. 1e18)
+    function setMultiplyingFactor(uint256 _multiplyingFactor) external onlyOwner {
+        if (_multiplyingFactor < MultiplierConstants.BASE_MULTIPLIER) revert InvalidMultiplyingFactor();
+        _getPOAPMultiplierStorage().multiplyingFactor = _multiplyingFactor;
+    }
+
+    /// @notice Update the POAP ERC-721 contract address
+    /// @param _poapContract New POAP contract address
+    function setPoapContract(IERC721 _poapContract) external onlyOwner {
+        _getPOAPMultiplierStorage().poapContract = _poapContract;
+    }
+
+    function _addEventId(uint256 _eventId) internal {
+        POAPMultiplierStorage storage $ = _getPOAPMultiplierStorage();
+        if ($.isQualifyingEventId[_eventId]) revert EventIdAlreadyAllowlisted(_eventId);
+        $.isQualifyingEventId[_eventId] = true;
+        $.qualifyingEventIds.push(_eventId);
+        emit EventIdAdded(_eventId);
+    }
+
+    // ───────────────────────── Public getters ─────────────────────────
+
+    /// @notice The POAP ERC-721 contract
+    function poapContract() external view returns (IERC721) {
+        return _getPOAPMultiplierStorage().poapContract;
+    }
+
+    /// @notice Multiplying factor granted to POAP holders
+    function multiplyingFactor() external view returns (uint256) {
+        return _getPOAPMultiplierStorage().multiplyingFactor;
+    }
+
+    /// @notice If true, any POAP qualifies
+    function acceptAnyPoap() external view returns (bool) {
+        return _getPOAPMultiplierStorage().acceptAnyPoap;
+    }
+
+    /// @notice Allowlisted POAP event IDs whose holders qualify
+    function qualifyingEventIds(uint256 index) external view returns (uint256) {
+        return _getPOAPMultiplierStorage().qualifyingEventIds[index];
+    }
+
+    /// @notice Number of qualifying event IDs
+    function qualifyingEventIdsLength() external view returns (uint256) {
+        return _getPOAPMultiplierStorage().qualifyingEventIds.length;
+    }
+
+    /// @notice O(1) lookup: event ID → whether it's approved
+    function isQualifyingEventId(uint256 eventId) external view returns (bool) {
+        return _getPOAPMultiplierStorage().isQualifyingEventId[eventId];
+    }
+
+    /// @notice The trusted off-chain oracle that attests qualifying POAP holders
+    function oracle() external view returns (address) {
+        return _getPOAPMultiplierStorage().oracle;
+    }
+
+    /// @notice Records addresses attested by the oracle as holding a qualifying POAP
+    function isAttested(address user) external view returns (bool) {
+        return _getPOAPMultiplierStorage().isAttested[user];
+    }
+}

--- a/src/multipliers/TBSNFTMultiplier.sol
+++ b/src/multipliers/TBSNFTMultiplier.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.22;
+
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+import {IMultiplier} from "src/interfaces/multipliers/IMultiplier.sol";
+import {MultiplierConstants} from "src/libraries/MultiplierConstants.sol";
+
+/// @title TBS NFT Multiplier
+/// @notice Grants a voting power boost to holders of The Bread Social (TBS) NFT.
+/// @dev Ownership of at least one TBS NFT token is sufficient to qualify.
+///      The TBS NFT contract address and multiplying factor are set at initialization
+///      and can be updated by the owner.
+contract TBSNFTMultiplier is Initializable, Ownable2StepUpgradeable, IMultiplier {
+    /// @custom:storage-location erc7201:breadchain.TBSNFTMultiplier.storage
+    struct TBSNFTMultiplierStorage {
+        /// @notice The TBS NFT ERC-721 contract
+        IERC721 tbsNFTContract;
+        /// @notice Multiplying factor granted to TBS NFT holders (fixed-point, 1e18 = 1x)
+        uint256 multiplyingFactor;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("breadchain.TBSNFTMultiplier.storage")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant TBS_NFT_MULTIPLIER_STORAGE_LOCATION =
+        0xaaf0cd467fca9524f0c356b2599e71096909e716f05151099dc61df46f997d00;
+
+    function _getTBSNFTMultiplierStorage() private pure returns (TBSNFTMultiplierStorage storage $) {
+        assembly {
+            $.slot := TBS_NFT_MULTIPLIER_STORAGE_LOCATION
+        }
+    }
+
+    /// @notice Error emitted when an invalid multiplying factor is provided
+    error InvalidMultiplyingFactor();
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Initializes the contract
+    /// @param _tbsNFTContract Address of the TBS NFT ERC-721 contract
+    /// @param _multiplyingFactor Boost factor for TBS holders (>= BASE_MULTIPLIER)
+    function initialize(IERC721 _tbsNFTContract, uint256 _multiplyingFactor) public initializer {
+        if (_multiplyingFactor < MultiplierConstants.BASE_MULTIPLIER) revert InvalidMultiplyingFactor();
+
+        __Ownable2Step_init();
+        _transferOwnership(msg.sender);
+
+        TBSNFTMultiplierStorage storage $ = _getTBSNFTMultiplierStorage();
+        $.tbsNFTContract = _tbsNFTContract;
+        $.multiplyingFactor = _multiplyingFactor;
+    }
+
+    /// @notice Returns the multiplying factor if the user holds at least one TBS NFT
+    /// @param _user The address of the user
+    /// @return The multiplyingFactor if the user owns a TBS NFT, 0 otherwise
+    function getMultiplyingFactor(address _user) external view override returns (uint256) {
+        TBSNFTMultiplierStorage storage $ = _getTBSNFTMultiplierStorage();
+        return $.tbsNFTContract.balanceOf(_user) > 0 ? $.multiplyingFactor : 0;
+    }
+
+    /// @notice The TBS multiplier is permanent; returns type(uint256).max
+    function validUntil(address /* _user */ ) external pure override returns (uint256) {
+        return type(uint256).max;
+    }
+
+    /// @notice No per-user state to update; computed fresh each call.
+    function updateMultiplyingFactor(address /* _user */ ) external pure override {
+        return;
+    }
+
+    // ───────────────────────── Admin ─────────────────────────
+
+    /// @notice Update the TBS NFT contract address
+    /// @param _tbsNFTContract New TBS NFT contract address
+    function setTBSNFTContract(IERC721 _tbsNFTContract) external onlyOwner {
+        _getTBSNFTMultiplierStorage().tbsNFTContract = _tbsNFTContract;
+    }
+
+    /// @notice Update the multiplying factor
+    /// @param _multiplyingFactor New factor (must be >= BASE_MULTIPLIER)
+    function setMultiplyingFactor(uint256 _multiplyingFactor) external onlyOwner {
+        if (_multiplyingFactor < MultiplierConstants.BASE_MULTIPLIER) revert InvalidMultiplyingFactor();
+        _getTBSNFTMultiplierStorage().multiplyingFactor = _multiplyingFactor;
+    }
+
+    // ───────────────────────── Public getters ─────────────────────────
+
+    /// @notice The TBS NFT ERC-721 contract
+    function tbsNFTContract() external view returns (IERC721) {
+        return _getTBSNFTMultiplierStorage().tbsNFTContract;
+    }
+
+    /// @notice Multiplying factor granted to TBS NFT holders
+    function multiplyingFactor() external view returns (uint256) {
+        return _getTBSNFTMultiplierStorage().multiplyingFactor;
+    }
+}

--- a/src/multipliers/VotingStreakMultiplier.sol
+++ b/src/multipliers/VotingStreakMultiplier.sol
@@ -13,21 +13,33 @@ import {YieldDistributor} from "src/YieldDistributor.sol";
 /// @notice A contract for managing voting streak multipliers
 /// @dev Implements IMultiplier and IVotingStreakMultiplier interfaces
 contract VotingStreakMultiplier is Initializable, OwnableUpgradeable, IMultiplier {
-    /// @notice The maximum number of times the multiplier can be incremented
-    uint256 public maxMultiplierIncrements;
+    /// @custom:storage-location erc7201:breadchain.VotingStreakMultiplier.storage
+    struct VotingStreakMultiplierStorage {
+        /// @notice The maximum number of times the multiplier can be incremented
+        uint256 maxMultiplierIncrements;
+        /// @notice The increment value for the multiplier
+        /// @dev must be a fixed-point representation of the percentage i.e. 1e18 (1%)
+        uint256 multiplierIncrement;
+        /// @notice The YieldDistributor contract
+        YieldDistributor yieldDistributor;
+        /// @notice Mapping of user addresses to their current multiplier factor
+        mapping(address => uint256) userToMultiplier;
+        /// @notice Mapping of user addresses to their multiplier validity period
+        mapping(address => uint256) userToValidUntil;
+        /// @notice Mapping of user addresses to the last cycle in which their streak was incremented
+        /// @dev Prevents streak from being incremented more than once per cycle (issue #185)
+        mapping(address => uint256) userLastUpdatedCycle;
+    }
 
-    /// @notice The increment value for the multiplier
-    /// @dev must be a fixed-point representation of the percentage i.e. 1e18 (1%)
-    uint256 public multiplierIncrement;
+    // keccak256(abi.encode(uint256(keccak256("breadchain.VotingStreakMultiplier.storage")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant VOTING_STREAK_MULTIPLIER_STORAGE_LOCATION =
+        0xf98a750b11127a77bc13d58ce3a725f7ac2c87a6348f796ba8ba8313c6565500;
 
-    /// @notice The YieldDistributor contract
-    YieldDistributor public yieldDistributor;
-
-    /// @notice Mapping of user addresses to their current multiplier factor
-    mapping(address => uint256) public userToMultiplier;
-
-    /// @notice Mapping of user addresses to their multiplier validity period
-    mapping(address => uint256) public userToValidUntil;
+    function _getVotingStreakMultiplierStorage() private pure returns (VotingStreakMultiplierStorage storage $) {
+        assembly {
+            $.slot := VOTING_STREAK_MULTIPLIER_STORAGE_LOCATION
+        }
+    }
 
     /// @notice Error emitted when an invalid multiplier increment is provided
     error InvalidMultiplierIncrement();
@@ -53,21 +65,23 @@ contract VotingStreakMultiplier is Initializable, OwnableUpgradeable, IMultiplie
     {
         __Ownable_init(msg.sender);
 
-        yieldDistributor = YieldDistributor(_yieldDistributor);
-        multiplierIncrement = _multiplierIncrement;
-        maxMultiplierIncrements = _maxMultiplierIncrements;
+        VotingStreakMultiplierStorage storage $ = _getVotingStreakMultiplierStorage();
+        $.yieldDistributor = YieldDistributor(_yieldDistributor);
+        $.multiplierIncrement = _multiplierIncrement;
+        $.maxMultiplierIncrements = _maxMultiplierIncrements;
     }
 
     /// @notice Gets the current multiplying factor for a user
     /// @param user The address of the user
     /// @return The current multiplying factor
     function getMultiplyingFactor(address user) public view override returns (uint256) {
+        VotingStreakMultiplierStorage storage $ = _getVotingStreakMultiplierStorage();
         if (
-            yieldDistributor.accountLastVoted(user)
-                    > yieldDistributor.lastClaimedBlockNumber() - yieldDistributor.cycleLength()
-                && block.number <= userToValidUntil[user]
+            $.yieldDistributor.accountLastVoted(user)
+                    > $.yieldDistributor.lastClaimedBlockNumber() - $.yieldDistributor.cycleLength()
+                && block.number <= $.userToValidUntil[user]
         ) {
-            return userToMultiplier[user];
+            return $.userToMultiplier[user];
         }
 
         // If the user does not have a multiplier, returning 1e18 ensures that the user's voting power is not modified by this multiplier
@@ -78,39 +92,52 @@ contract VotingStreakMultiplier is Initializable, OwnableUpgradeable, IMultiplie
     /// @param user The address of the user
     /// @return The block number until which the multiplier is valid
     function validUntil(address user) external view override returns (uint256) {
-        return userToValidUntil[user];
+        return _getVotingStreakMultiplierStorage().userToValidUntil[user];
     }
 
     /// @notice Updates the multiplying factor for a user
     /// @param _user The address of the user to update the multiplying factor for
     function updateMultiplyingFactor(address _user) external override {
+        VotingStreakMultiplierStorage storage $ = _getVotingStreakMultiplierStorage();
+
         // Check if user has already voted in current cycle
-        uint256 lastVotedBlock = yieldDistributor.accountLastVoted(_user);
-        uint256 lastClaimedBlock = yieldDistributor.lastClaimedBlockNumber();
-        uint256 cycleLength = yieldDistributor.cycleLength();
+        uint256 lastVotedBlock = $.yieldDistributor.accountLastVoted(_user);
+        uint256 lastClaimedBlock = $.yieldDistributor.lastClaimedBlockNumber();
+        uint256 cycleLength = $.yieldDistributor.cycleLength();
+        uint256 currentCycle = $.yieldDistributor.votingCycle();
 
         // If user has already voted in current cycle, do nothing
         if (lastVotedBlock > lastClaimedBlock) {
             return;
         }
 
+        // Prevent streak from being incremented more than once per cycle (issue #185)
+        // Without this check, a user could call updateMultiplyingFactor (or castVoteWithMultipliers)
+        // multiple times before their first vote to max the streak in a single cycle.
+        if ($.userLastUpdatedCycle[_user] == currentCycle) {
+            return;
+        }
+
         uint256 currentMultiplier = getMultiplyingFactor(_user);
         uint256 newMultiplier = (currentMultiplier == MultiplierConstants.BASE_MULTIPLIER)
-            ? MultiplierConstants.BASE_MULTIPLIER + multiplierIncrement
+            ? MultiplierConstants.BASE_MULTIPLIER + $.multiplierIncrement
             : Math.min(
-                currentMultiplier + multiplierIncrement,
-                (MultiplierConstants.BASE_MULTIPLIER + (maxMultiplierIncrements * multiplierIncrement))
+                currentMultiplier + $.multiplierIncrement,
+                (MultiplierConstants.BASE_MULTIPLIER + ($.maxMultiplierIncrements * $.multiplierIncrement))
             );
 
-        userToMultiplier[_user] = newMultiplier;
-        userToValidUntil[_user] = lastClaimedBlock + (2 * cycleLength);
-        emit MultiplierUpdated(_user, newMultiplier, userToValidUntil[_user]);
+        $.userLastUpdatedCycle[_user] = currentCycle;
+        $.userToMultiplier[_user] = newMultiplier;
+        $.userToValidUntil[_user] = lastClaimedBlock + (2 * cycleLength);
+        emit MultiplierUpdated(_user, newMultiplier, $.userToValidUntil[_user]);
     }
 
-    /// @notice Sets the YieldDistributor contract address
+    /// @notice Sets the YieldDistributor contract address used to read cycle and vote state
+    /// @dev Updating this also changes which contract is queried for `votingCycle`,
+    ///      `lastClaimedBlockNumber`, `cycleLength`, and `accountLastVoted`.
     /// @param _yieldDistributor The new YieldDistributor contract address
     function setYieldDistributor(address _yieldDistributor) external onlyOwner {
-        yieldDistributor = YieldDistributor(_yieldDistributor);
+        _getVotingStreakMultiplierStorage().yieldDistributor = YieldDistributor(_yieldDistributor);
     }
 
     /// @notice Sets the multiplier increment value
@@ -119,12 +146,44 @@ contract VotingStreakMultiplier is Initializable, OwnableUpgradeable, IMultiplie
         if (_multiplierIncrement == 0) {
             revert InvalidMultiplierIncrement();
         }
-        multiplierIncrement = _multiplierIncrement;
+        _getVotingStreakMultiplierStorage().multiplierIncrement = _multiplierIncrement;
     }
 
     /// @notice Sets the maximum number of times the multiplier can be incremented
     /// @param _maxMultiplierIncrements The new maximum number of times the multiplier can be incremented
     function setMaxMultiplierIncrements(uint256 _maxMultiplierIncrements) external onlyOwner {
-        maxMultiplierIncrements = _maxMultiplierIncrements;
+        _getVotingStreakMultiplierStorage().maxMultiplierIncrements = _maxMultiplierIncrements;
+    }
+
+    // ───────────────────────── Public getters ─────────────────────────
+
+    /// @notice The maximum number of times the multiplier can be incremented
+    function maxMultiplierIncrements() external view returns (uint256) {
+        return _getVotingStreakMultiplierStorage().maxMultiplierIncrements;
+    }
+
+    /// @notice The increment value for the multiplier
+    function multiplierIncrement() external view returns (uint256) {
+        return _getVotingStreakMultiplierStorage().multiplierIncrement;
+    }
+
+    /// @notice The YieldDistributor contract
+    function yieldDistributor() external view returns (YieldDistributor) {
+        return _getVotingStreakMultiplierStorage().yieldDistributor;
+    }
+
+    /// @notice Mapping of user addresses to their current multiplier factor
+    function userToMultiplier(address user) external view returns (uint256) {
+        return _getVotingStreakMultiplierStorage().userToMultiplier[user];
+    }
+
+    /// @notice Mapping of user addresses to their multiplier validity period
+    function userToValidUntil(address user) external view returns (uint256) {
+        return _getVotingStreakMultiplierStorage().userToValidUntil[user];
+    }
+
+    /// @notice Mapping of user addresses to the last cycle in which their streak was incremented
+    function userLastUpdatedCycle(address user) external view returns (uint256) {
+        return _getVotingStreakMultiplierStorage().userLastUpdatedCycle[user];
     }
 }

--- a/src/test/YieldDistributorTestWrapper.sol
+++ b/src/test/YieldDistributorTestWrapper.sol
@@ -29,4 +29,12 @@ contract YieldDistributorTestWrapper is YieldDistributor {
     function setLastClaimedBlockNumber(uint256 _lastClaimedBlockNumber) public onlyOwner {
         lastClaimedBlockNumber = _lastClaimedBlockNumber;
     }
+
+    /**
+     * @notice Set the voting cycle number (for testing cycle-dependent guards)
+     * @param _votingCycle New voting cycle number
+     */
+    function setVotingCycle(uint256 _votingCycle) public onlyOwner {
+        votingCycle = _votingCycle;
+    }
 }

--- a/test/YieldDistributor.t.sol
+++ b/test/YieldDistributor.t.sol
@@ -673,6 +673,7 @@ contract VotingStreakMultiplierTest is YieldDistributorTest {
     function setUpForCycle(YieldDistributorTestWrapper _yieldDistributor, uint256 iterator) public {
         vm.roll(START + (_cycleLength * (iterator)));
         _yieldDistributor.setLastClaimedBlockNumber(vm.getBlockNumber());
+        _yieldDistributor.setVotingCycle(iterator + 1);
         address owner = bread.owner();
         vm.prank(owner);
         bread.setYieldClaimer(address(_yieldDistributor));


### PR DESCRIPTION
## Summary
Migrates upgradeable contracts to use ERC-7201 namespaced storage slots.

## Changes
- Multiplier contracts (7): Full ERC-7201 migration — all storage wrapped in namespaced structs
- Deployed contracts (YieldDistributor, ButteredBread): freeze + namespace approach with __gap arrays
- VotingMultipliers.sol: Already ERC-7201 compliant
- PermanentNFTMultiplier.sol: Non-upgradeable, skipped

## Breaking Change
Requires proxy redeployment. Coordinate with Bread Coop team for migration timing.

## Testing
- All 107 tests passing
- forge build: 0 warnings, 0 errors

Closes #112
