### PR TITLE
fix: clamp withdraw burn to actual balance to prevent full-unlock revert

### DIFF
--- a/src/ButteredBread.sol
+++ b/src/ButteredBread.sol
@@ -165,7 +165,17 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, Ownable2StepUpg
         _syncVotingWeight(_account, _lp);
         _accountToLPData[_account][_lp].balance -= _amount;
 
-        _burn(_account, _amount * scalingFactors[_lp] / FIXED_POINT_PERCENT);
+        /// @dev `_deposit` mints per-call with integer division, so summing several deposits and
+        /// withdrawing them in one call can compute a burn amount larger than what was actually
+        /// minted (floor(a) + floor(b) <= floor(a + b)). Clamp to the account's real balance so a
+        /// full withdrawal can never revert with an ERC20 insufficient-balance error; this can only
+        /// reduce the burn amount, never increase it, so it can't let an account escape with more
+        /// LP than it's owed.
+        uint256 burnAmount = _amount * scalingFactors[_lp] / FIXED_POINT_PERCENT;
+        uint256 accountBalance = balanceOf(_account);
+        if (burnAmount > accountBalance) burnAmount = accountBalance;
+        _burn(_account, burnAmount);
+
         bool success = IERC20(_lp).transfer(_account, _amount);
         if (!success) revert TransferFailed();
 

--- a/test/ButteredBread.t.sol
+++ b/test/ButteredBread.t.sol
@@ -229,6 +229,52 @@ contract ButteredBreadTest_Unit is ButteredBreadTest {
         bb.withdraw(GNOSIS_CURVE_POOL_XDAI_BREAD, depositAmount + 1);
     }
 
+    /// @notice Reproduces the bug from crowdstaking-v2 issue #408: when a scaling factor doesn't
+    /// divide FIXED_POINT_PERCENT evenly (eg. the live BUTTER scaling factor of 32), minting on
+    /// each deposit floors independently, but a single full withdrawal floors the summed amount.
+    /// Since floor(a) + floor(b) <= floor(a + b), an account that deposited in more than one
+    /// transaction can end up owing more ButteredBread than it holds when it withdraws everything
+    /// at once, reverting the withdrawal entirely. Before the `_withdraw` clamp, this reverted with
+    /// `ERC20InsufficientBalance`.
+    function testWithdrawAndBurnFullBalanceAfterMultipleDeposits() public {
+        ERC20Mock mockLp = new ERC20Mock();
+        address[] memory emptyList = new address[](0);
+        uint256 oddScalingFactor = 133; // does not divide 100 evenly
+
+        bb.modifyScalingFactor(address(mockLp), oddScalingFactor, emptyList);
+        bb.modifyAllowList(address(mockLp), true);
+
+        uint256 firstDeposit = 33;
+        uint256 secondDeposit = 67;
+        uint256 totalDeposit = firstDeposit + secondDeposit;
+
+        mockLp.mint(ALICE, totalDeposit);
+
+        vm.startPrank(ALICE);
+        mockLp.approve(address(bb), totalDeposit);
+        bb.deposit(address(mockLp), firstDeposit);
+        bb.deposit(address(mockLp), secondDeposit);
+
+        uint256 mintedFromDeposits =
+            firstDeposit * oddScalingFactor / fixedPointPercent + secondDeposit * oddScalingFactor / fixedPointPercent;
+        uint256 burnRequiredForFullWithdraw = totalDeposit * oddScalingFactor / fixedPointPercent;
+
+        // The rounding shortfall this bug relies on.
+        assertLt(mintedFromDeposits, burnRequiredForFullWithdraw);
+        assertEq(bb.balanceOf(ALICE), mintedFromDeposits);
+
+        uint256 lockedBalance = bb.accountToLPBalance(ALICE, address(mockLp));
+        assertEq(lockedBalance, totalDeposit);
+
+        // Prior to the fix, this reverted with ERC20InsufficientBalance.
+        bb.withdraw(address(mockLp), lockedBalance);
+        vm.stopPrank();
+
+        assertEq(bb.accountToLPBalance(ALICE, address(mockLp)), 0);
+        assertEq(bb.balanceOf(ALICE), 0);
+        assertEq(mockLp.balanceOf(ALICE), totalDeposit);
+    }
+
     function testMintScalingFactor() public {
         assertEq(bb.scalingFactors(GNOSIS_CURVE_POOL_XDAI_BREAD), XDAI_FACTOR);
 


### PR DESCRIPTION
_deposit mints per-call with integer division (amount * scalingFactor / FIXED_POINT_PERCENT), so summing several deposits and withdrawing them in one call can compute a burn amount larger than what was actually minted, since floor(a) + floor(b) <= floor(a + b). On the live Gnosis deployment the BUTTER scaling factor (32) rarely divides evenly, so any account that deposited more than once and tries to unlock its full balance in one withdraw() hits ERC20InsufficientBalance and the transaction reverts every time (crowdstaking-v2 #408).

Clamp the burn to the account's actual ButteredBread balance instead. This can only reduce the burn amount, never increase it, so it can't let an account withdraw LP without burning the voting power it holds.