### PR TITLE
fix: burn the difference of scaled balances so full LP withdrawals clear

### DIFF
--- a/src/ButteredBread.sol
+++ b/src/ButteredBread.sol
@@ -150,23 +150,31 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, Ownable2StepUpg
 
         /// @dev ensure proper accounting in case of admin error in `modifyScalingFactor` where not all holders are updated
         _syncVotingWeight(_account, _lp);
-        _accountToLPData[_account][_lp].balance += _amount;
 
-        _mint(_account, _amount * scalingFactors[_lp] / FIXED_POINT_PERCENT);
+        uint256 previousBalance = _accountToLPData[_account][_lp].balance;
+        uint256 newBalance = previousBalance + _amount;
+        _accountToLPData[_account][_lp].balance = newBalance;
+
+        _mint(_account, _scaledBalance(newBalance, _lp) - _scaledBalance(previousBalance, _lp));
 
         emit ButterAdded(_account, _lp, _amount);
     }
 
     /// @notice Withdraw LP tokens and burn ButteredBread with corresponding LP scaling factor
     function _withdraw(address _account, address _lp, uint256 _amount) internal {
-        if (_amount > _accountToLPData[_account][_lp].balance) revert InsufficientFunds();
+        uint256 previousBalance = _accountToLPData[_account][_lp].balance;
+        if (_amount > previousBalance) revert InsufficientFunds();
         _syncDelegation(_account);
 
         /// @dev ensure proper accounting in case of admin error in `modifyScalingFactor` where not all holders are updated
         _syncVotingWeight(_account, _lp);
-        _accountToLPData[_account][_lp].balance -= _amount;
 
-        _burn(_account, _amount * scalingFactors[_lp] / FIXED_POINT_PERCENT);
+        /// @dev `_syncVotingWeight` only adjusts the stored scaling factor, so `previousBalance` is still current
+        uint256 newBalance = previousBalance - _amount;
+        _accountToLPData[_account][_lp].balance = newBalance;
+
+        _burnUpToBalance(_account, _scaledBalance(previousBalance, _lp) - _scaledBalance(newBalance, _lp));
+
         bool success = IERC20(_lp).transfer(_account, _amount);
         if (!success) revert TransferFailed();
 
@@ -201,18 +209,33 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, Ownable2StepUpg
             _accountToLPData[_account][_lp].scalingFactor = currentScalingFactor;
 
             if (lpBalance > 0) {
-                if (currentScalingFactor > initialScalingFactor) {
-                    _mint(
-                        _account,
-                        (lpBalance * currentScalingFactor - lpBalance * initialScalingFactor) / FIXED_POINT_PERCENT
-                    );
+                /// @dev difference of scaled balances, matching how `_deposit` and `_withdraw` scale
+                uint256 currentWeight = lpBalance * currentScalingFactor / FIXED_POINT_PERCENT;
+                uint256 initialWeight = lpBalance * initialScalingFactor / FIXED_POINT_PERCENT;
+
+                if (currentWeight > initialWeight) {
+                    _mint(_account, currentWeight - initialWeight);
                 } else {
-                    _burn(
-                        _account,
-                        (lpBalance * initialScalingFactor - lpBalance * currentScalingFactor) / FIXED_POINT_PERCENT
-                    );
+                    _burnUpToBalance(_account, initialWeight - currentWeight);
                 }
             }
         }
+    }
+
+    /// @notice Apply the scaling factor of a liquidity pool to an LP token balance
+    function _scaledBalance(uint256 _balance, address _lp) internal view returns (uint256) {
+        return _balance * scalingFactors[_lp] / FIXED_POINT_PERCENT;
+    }
+
+    /**
+     * @notice Burn `ButteredBread`, capped at the balance of the account
+     * @dev Accounts that deposited before scaled balances were differenced hold slightly less `ButteredBread`
+     *  than their aggregate entitlement, because each deposit floored its own mint. Capping lets those accounts
+     *  withdraw their full LP balance instead of reverting in `_burn`. For every deposit made under the current
+     *  accounting the requested amount is already covered, so the cap does not apply.
+     */
+    function _burnUpToBalance(address _account, uint256 _amount) internal {
+        uint256 accountBalance = balanceOf(_account);
+        _burn(_account, _amount > accountBalance ? accountBalance : _amount);
     }
 }

--- a/test/ButteredBread.t.sol
+++ b/test/ButteredBread.t.sol
@@ -377,11 +377,12 @@ contract ButteredBreadTest_Fuzz is ButteredBreadTest {
         assertEq(bb.accountToLPBalance(ALICE, GNOSIS_CURVE_POOL_XDAI_BREAD), _s.deposit);
         assertEq(curvePoolXdai.balanceOf(ALICE), 0);
 
-        uint256 preWithdrawBalance = bb.balanceOf(ALICE);
         bb.withdraw(GNOSIS_CURVE_POOL_XDAI_BREAD, _s.withdrawal);
 
-        assertEq(bb.balanceOf(ALICE), preWithdrawBalance - (_s.withdrawal * _s.initialFactor / fixedPointPercent));
-        assertEq(bb.accountToLPBalance(ALICE, GNOSIS_CURVE_POOL_XDAI_BREAD), _s.deposit - _s.withdrawal);
+        uint256 remainingBalance = _s.deposit - _s.withdrawal;
+        /// @dev the burn is the difference of scaled balances, so the holding always matches the scaled remainder
+        assertEq(bb.balanceOf(ALICE), remainingBalance * _s.initialFactor / fixedPointPercent);
+        assertEq(bb.accountToLPBalance(ALICE, GNOSIS_CURVE_POOL_XDAI_BREAD), remainingBalance);
         assertEq(curvePoolXdai.balanceOf(ALICE), _s.withdrawal);
     }
 
@@ -577,5 +578,173 @@ contract ButteredBreadTest_Integration is ButteredBreadTest {
         uint256 bbBalance = bb.balanceOf(ALICE);
         uint256 bBalance = IERC20(GNOSIS_BREAD).balanceOf(ALICE);
         assertEq(yieldDistributor.getCurrentVotingPower(ALICE), bbBalance + bBalance);
+    }
+}
+
+/**
+ * @dev Regression coverage for scaling factors that are not a whole multiple of `FIXED_POINT_PERCENT`.
+ *  The mint in `_deposit` floors once per deposit while the burn in `_withdraw` floors over the aggregate
+ *  balance, so a sum of floors could fall short of the floor of the sum and a full withdrawal reverted in
+ *  `_burn` with `ERC20InsufficientBalance`. Existing suites only exercise `XDAI_FACTOR` (700), an exact
+ *  multiple of 100, where every division is exact and the shortfall cannot appear.
+ */
+contract ButteredBreadTest_WithdrawRounding is ButteredBreadTest {
+    /// @dev Scaling factor of the live BREAD/WXDAI deployment, which is not a multiple of `FIXED_POINT_PERCENT`
+    uint256 public constant LIVE_FACTOR = 32;
+    /// @dev Factor satisfying the documented `>= FIXED_POINT_PERCENT` invariant that still truncates
+    uint256 public constant FRACTIONAL_FACTOR = 132;
+
+    /// @dev Deposits made by 0x37cc13650d0D2A73E181cbF48A1847AE5f0531b5, the account reported in #408
+    uint256 public constant LIVE_DEPOSIT_ONE = 2_146_701_100_755_580_030_478;
+    uint256 public constant LIVE_DEPOSIT_TWO = 485_633_753_042_731_023_542;
+
+    function setUp() public virtual override {
+        super.setUp();
+        _helperAddLiquidity(ALICE, 2500 ether, 2500 ether);
+    }
+
+    /// @dev Deploy a separate proxy so a scaling factor below `FIXED_POINT_PERCENT` can be set through `initialize`
+    function _deployWithFactor(uint256 _factor) internal returns (ButteredBread _bb) {
+        address[] memory _liquidityPools = new address[](1);
+        _liquidityPools[0] = GNOSIS_CURVE_POOL_XDAI_BREAD;
+
+        uint256[] memory _scalingFactors = new uint256[](1);
+        _scalingFactors[0] = _factor;
+
+        IButteredBread.InitData memory initData = IButteredBread.InitData({
+            breadToken: GNOSIS_BREAD,
+            liquidityPools: _liquidityPools,
+            scalingFactors: _scalingFactors,
+            name: "ButteredBread",
+            symbol: "BB"
+        });
+
+        _bb = ButteredBread(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(new ButteredBread()),
+                    address(this),
+                    abi.encodeWithSelector(ButteredBread.initialize.selector, initData)
+                )
+            )
+        );
+
+        vm.prank(ALICE);
+        curvePoolXdai.approve(address(_bb), type(uint256).max);
+    }
+
+    /// @dev Two deposits then a full withdrawal, replicating the exact amounts of the reported account
+    function testWithdrawFullBalanceAfterTwoDeposits() public {
+        ButteredBread _bb = _deployWithFactor(LIVE_FACTOR);
+
+        vm.startPrank(ALICE);
+        _bb.deposit(GNOSIS_CURVE_POOL_XDAI_BREAD, LIVE_DEPOSIT_ONE);
+        _bb.deposit(GNOSIS_CURVE_POOL_XDAI_BREAD, LIVE_DEPOSIT_TWO);
+
+        uint256 stakedBalance = _bb.accountToLPBalance(ALICE, GNOSIS_CURVE_POOL_XDAI_BREAD);
+        assertEq(stakedBalance, LIVE_DEPOSIT_ONE + LIVE_DEPOSIT_TWO);
+
+        /// @dev The frontend unlocks the full reported balance, which is the amount that reverted
+        _bb.withdraw(GNOSIS_CURVE_POOL_XDAI_BREAD, stakedBalance);
+        vm.stopPrank();
+
+        assertEq(_bb.accountToLPBalance(ALICE, GNOSIS_CURVE_POOL_XDAI_BREAD), 0);
+        assertEq(_bb.balanceOf(ALICE), 0);
+        assertEq(curvePoolXdai.balanceOf(address(_bb)), 0);
+    }
+
+    /// @dev The same shortfall arises for a factor that respects the documented `>= FIXED_POINT_PERCENT` invariant
+    function testWithdrawFullBalanceFractionalFactor() public {
+        ButteredBread _bb = _deployWithFactor(FRACTIONAL_FACTOR);
+
+        vm.startPrank(ALICE);
+        _bb.deposit(GNOSIS_CURVE_POOL_XDAI_BREAD, 1 ether + 1);
+        _bb.deposit(GNOSIS_CURVE_POOL_XDAI_BREAD, 1 ether + 3);
+
+        uint256 stakedBalance = _bb.accountToLPBalance(ALICE, GNOSIS_CURVE_POOL_XDAI_BREAD);
+        _bb.withdraw(GNOSIS_CURVE_POOL_XDAI_BREAD, stakedBalance);
+        vm.stopPrank();
+
+        assertEq(_bb.accountToLPBalance(ALICE, GNOSIS_CURVE_POOL_XDAI_BREAD), 0);
+        assertEq(_bb.balanceOf(ALICE), 0);
+    }
+
+    /// @dev Cumulative minted supply must equal the aggregate entitlement so a full exit always clears
+    function testMintedSupplyMatchesAggregateEntitlement() public {
+        ButteredBread _bb = _deployWithFactor(LIVE_FACTOR);
+
+        vm.startPrank(ALICE);
+        _bb.deposit(GNOSIS_CURVE_POOL_XDAI_BREAD, LIVE_DEPOSIT_ONE);
+        _bb.deposit(GNOSIS_CURVE_POOL_XDAI_BREAD, LIVE_DEPOSIT_TWO);
+        vm.stopPrank();
+
+        uint256 stakedBalance = _bb.accountToLPBalance(ALICE, GNOSIS_CURVE_POOL_XDAI_BREAD);
+        assertEq(_bb.balanceOf(ALICE), stakedBalance * LIVE_FACTOR / fixedPointPercent);
+    }
+
+    /// @dev A withdrawal small enough to floor to zero must not return LP while retaining voting weight
+    function testDustWithdrawalDoesNotRetainVotingWeight() public {
+        ButteredBread _bb = _deployWithFactor(LIVE_FACTOR);
+
+        vm.startPrank(ALICE);
+        _bb.deposit(GNOSIS_CURVE_POOL_XDAI_BREAD, 100 ether);
+
+        uint256 balanceBefore = _bb.balanceOf(ALICE);
+        /// @dev `3 * 32 / 100` floors to zero under the previous arithmetic
+        _bb.withdraw(GNOSIS_CURVE_POOL_XDAI_BREAD, 3);
+        vm.stopPrank();
+
+        assertLt(_bb.balanceOf(ALICE), balanceBefore);
+        assertEq(
+            _bb.balanceOf(ALICE),
+            _bb.accountToLPBalance(ALICE, GNOSIS_CURVE_POOL_XDAI_BREAD) * LIVE_FACTOR / fixedPointPercent
+        );
+    }
+
+    /// @dev Any sequence of deposits must leave the whole staked balance withdrawable in one call
+    function testFuzzFullWithdrawAfterArbitraryDeposits(uint256 _first, uint256 _second, uint256 _factor) public {
+        uint256 factor = bound(_factor, 1, 10_000);
+        uint256 available = curvePoolXdai.balanceOf(ALICE) / 2;
+        uint256 first = bound(_first, 1, available);
+        uint256 second = bound(_second, 1, available);
+
+        ButteredBread _bb = _deployWithFactor(factor);
+
+        vm.startPrank(ALICE);
+        _bb.deposit(GNOSIS_CURVE_POOL_XDAI_BREAD, first);
+        _bb.deposit(GNOSIS_CURVE_POOL_XDAI_BREAD, second);
+
+        uint256 stakedBalance = _bb.accountToLPBalance(ALICE, GNOSIS_CURVE_POOL_XDAI_BREAD);
+        assertEq(stakedBalance, first + second);
+
+        _bb.withdraw(GNOSIS_CURVE_POOL_XDAI_BREAD, stakedBalance);
+        vm.stopPrank();
+
+        assertEq(_bb.accountToLPBalance(ALICE, GNOSIS_CURVE_POOL_XDAI_BREAD), 0);
+        assertEq(_bb.balanceOf(ALICE), 0);
+    }
+
+    /// @dev Partial withdrawals in arbitrary chunks must never strand LP or desync the scaled balance
+    function testFuzzPartialWithdrawalsKeepBalancesInSync(uint256 _deposit, uint256 _chunk, uint256 _factor) public {
+        uint256 factor = bound(_factor, 1, 10_000);
+        uint256 depositAmount = bound(_deposit, 2, curvePoolXdai.balanceOf(ALICE));
+        uint256 chunk = bound(_chunk, 1, depositAmount);
+
+        ButteredBread _bb = _deployWithFactor(factor);
+
+        vm.startPrank(ALICE);
+        _bb.deposit(GNOSIS_CURVE_POOL_XDAI_BREAD, depositAmount);
+        _bb.withdraw(GNOSIS_CURVE_POOL_XDAI_BREAD, chunk);
+
+        uint256 remaining = _bb.accountToLPBalance(ALICE, GNOSIS_CURVE_POOL_XDAI_BREAD);
+        assertEq(remaining, depositAmount - chunk);
+        assertEq(_bb.balanceOf(ALICE), remaining * factor / fixedPointPercent);
+
+        if (remaining > 0) _bb.withdraw(GNOSIS_CURVE_POOL_XDAI_BREAD, remaining);
+        vm.stopPrank();
+
+        assertEq(_bb.accountToLPBalance(ALICE, GNOSIS_CURVE_POOL_XDAI_BREAD), 0);
+        assertEq(_bb.balanceOf(ALICE), 0);
+        assertEq(curvePoolXdai.balanceOf(address(_bb)), 0);
     }
 }

--- a/test/ButteredBreadUpgrade.t.sol
+++ b/test/ButteredBreadUpgrade.t.sol
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.25;
+
+import "script/Constants.s.sol";
+import {Test} from "forge-std/Test.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {ButteredBread} from "src/ButteredBread.sol";
+
+/// @dev Live `ButteredBread` proxy on Gnosis
+address constant GNOSIS_BUTTERED_BREAD = 0x680B581605DC0A6902735a80dE35Cb0Ef6E90865;
+/// @dev `ProxyAdmin` owning the live proxy
+address constant GNOSIS_BUTTERED_BREAD_PROXY_ADMIN = 0x671180547cD5AAaedEf2B087d3d7Ed9166AfceB6;
+
+/// @dev Block at which the accounts below were unable to withdraw their full LP balance
+uint256 constant FORK_BLOCK = 47_651_977;
+
+interface IProxyAdmin {
+    function owner() external view returns (address);
+    function upgradeAndCall(address proxy, address implementation, bytes memory data) external payable;
+}
+
+/**
+ * @notice Verifies the deployed proxy against accounts that could not withdraw
+ * @dev Deposits made before this fix hold slightly less `ButteredBread` than their aggregate entitlement, so the
+ *  burn in `_withdraw` exceeded their balance and a full withdrawal reverted. Upgrading must let each of them exit
+ *  in a single call. See BreadchainCoop/crowdstaking-v2#408
+ */
+contract ButteredBreadUpgradeTest is Test {
+    ButteredBread public bb;
+    IERC20 public lp;
+
+    /// @dev Accounts holding a position that could not be fully withdrawn at `FORK_BLOCK`
+    address[3] public affectedAccounts = [
+        0x37cc13650d0D2A73E181cbF48A1847AE5f0531b5,
+        0x18A725aD96aE6a8b6e8DbE3FB3a8eb042e2F8879,
+        0xcF26fE037743F56daB8f9CA509E9FB7f59071BF1
+    ];
+
+    function setUp() public {
+        vm.createSelectFork(vm.rpcUrl("gnosis"), FORK_BLOCK);
+        bb = ButteredBread(GNOSIS_BUTTERED_BREAD);
+        lp = IERC20(GNOSIS_CURVE_POOL_XDAI_BREAD);
+    }
+
+    function _upgradeToFixedImplementation() internal {
+        IProxyAdmin proxyAdmin = IProxyAdmin(GNOSIS_BUTTERED_BREAD_PROXY_ADMIN);
+        address newImplementation = address(new ButteredBread());
+
+        vm.prank(proxyAdmin.owner());
+        proxyAdmin.upgradeAndCall(GNOSIS_BUTTERED_BREAD, newImplementation, "");
+    }
+
+    /// @dev Confirms the reverting state is real before the upgrade is applied
+    function testFullWithdrawRevertsBeforeUpgrade() public {
+        for (uint256 i; i < affectedAccounts.length; ++i) {
+            address account = affectedAccounts[i];
+            uint256 stakedBalance = bb.accountToLPBalance(account, GNOSIS_CURVE_POOL_XDAI_BREAD);
+            assertGt(stakedBalance, 0);
+
+            vm.prank(account);
+            vm.expectRevert();
+            bb.withdraw(GNOSIS_CURVE_POOL_XDAI_BREAD, stakedBalance);
+        }
+    }
+
+    /// @dev Each affected account must recover its entire staked balance in a single call after the upgrade
+    function testFullWithdrawSucceedsAfterUpgrade() public {
+        _upgradeToFixedImplementation();
+
+        for (uint256 i; i < affectedAccounts.length; ++i) {
+            address account = affectedAccounts[i];
+            uint256 stakedBalance = bb.accountToLPBalance(account, GNOSIS_CURVE_POOL_XDAI_BREAD);
+            uint256 walletBalanceBefore = lp.balanceOf(account);
+
+            vm.prank(account);
+            bb.withdraw(GNOSIS_CURVE_POOL_XDAI_BREAD, stakedBalance);
+
+            assertEq(lp.balanceOf(account), walletBalanceBefore + stakedBalance);
+            assertEq(bb.accountToLPBalance(account, GNOSIS_CURVE_POOL_XDAI_BREAD), 0);
+            assertEq(bb.balanceOf(account), 0);
+        }
+    }
+
+    /// @dev The upgrade adds no storage, so existing positions and voting weight must be untouched
+    function testUpgradePreservesExistingState() public {
+        uint256 totalSupplyBefore = bb.totalSupply();
+        uint256 contractLpBefore = lp.balanceOf(GNOSIS_BUTTERED_BREAD);
+        uint256 scalingFactorBefore = bb.scalingFactors(GNOSIS_CURVE_POOL_XDAI_BREAD);
+
+        uint256[3] memory stakedBefore;
+        uint256[3] memory holdingBefore;
+        for (uint256 i; i < affectedAccounts.length; ++i) {
+            stakedBefore[i] = bb.accountToLPBalance(affectedAccounts[i], GNOSIS_CURVE_POOL_XDAI_BREAD);
+            holdingBefore[i] = bb.balanceOf(affectedAccounts[i]);
+        }
+
+        _upgradeToFixedImplementation();
+
+        assertEq(bb.totalSupply(), totalSupplyBefore);
+        assertEq(lp.balanceOf(GNOSIS_BUTTERED_BREAD), contractLpBefore);
+        assertEq(bb.scalingFactors(GNOSIS_CURVE_POOL_XDAI_BREAD), scalingFactorBefore);
+        assertTrue(bb.allowlistedLPs(GNOSIS_CURVE_POOL_XDAI_BREAD));
+
+        for (uint256 i; i < affectedAccounts.length; ++i) {
+            assertEq(bb.accountToLPBalance(affectedAccounts[i], GNOSIS_CURVE_POOL_XDAI_BREAD), stakedBefore[i]);
+            assertEq(bb.balanceOf(affectedAccounts[i]), holdingBefore[i]);
+        }
+    }
+
+    /// @dev A deposit and withdrawal cycle on the upgraded proxy must leave no residual holding
+    function testDepositAndFullWithdrawAfterUpgrade() public {
+        _upgradeToFixedImplementation();
+
+        address account = affectedAccounts[0];
+        uint256 stakedBalance = bb.accountToLPBalance(account, GNOSIS_CURVE_POOL_XDAI_BREAD);
+
+        vm.startPrank(account);
+        bb.withdraw(GNOSIS_CURVE_POOL_XDAI_BREAD, stakedBalance);
+
+        /// @dev redeposit the recovered balance in two parts, the pattern that produced the shortfall
+        lp.approve(GNOSIS_BUTTERED_BREAD, type(uint256).max);
+        bb.deposit(GNOSIS_CURVE_POOL_XDAI_BREAD, stakedBalance / 3);
+        bb.deposit(GNOSIS_CURVE_POOL_XDAI_BREAD, stakedBalance - (stakedBalance / 3));
+
+        uint256 restakedBalance = bb.accountToLPBalance(account, GNOSIS_CURVE_POOL_XDAI_BREAD);
+        assertEq(restakedBalance, stakedBalance);
+
+        bb.withdraw(GNOSIS_CURVE_POOL_XDAI_BREAD, restakedBalance);
+        vm.stopPrank();
+
+        assertEq(bb.accountToLPBalance(account, GNOSIS_CURVE_POOL_XDAI_BREAD), 0);
+        assertEq(bb.balanceOf(account), 0);
+        assertEq(lp.balanceOf(account), stakedBalance);
+    }
+}


### PR DESCRIPTION
Fixes the withdrawal failures reported in BreadchainCoop/crowdstaking-v2#408, where users could not unlock their LP tokens.

## Problem

`_deposit` floored its mint once per deposit, while `_withdraw` floored over the aggregate balance:

```solidity
// _deposit  →  floor() applied once per deposit
_mint(_account, _amount * scalingFactors[_lp] / FIXED_POINT_PERCENT);

// _withdraw →  floor() applied to the total
_burn(_account, _amount * scalingFactors[_lp] / FIXED_POINT_PERCENT);
```

A sum of floors can fall short of the floor of the sum. So for any account that deposited **more than once**, withdrawing the full balance tried to burn more `ButteredBread` than was ever minted to them, and `_burn` reverted with `ERC20InsufficientBalance`.

The frontend unlocks the full `accountToLPBalance`, which is exactly the amount that reverts — so affected users could never succeed, regardless of wallet. Wallets that simulate before prompting (Safe, Rabby) refuse to open or hang on "in process", which is how this surfaced in the issue.

**Why it went unnoticed:** the live BREAD/WXDAI pool has a scaling factor of `32`, which is not a multiple of `FIXED_POINT_PERCENT`, so every deposit truncates. The existing suites only exercise `XDAI_FACTOR = 700`, an exact multiple of 100 where every division is exact and the shortfall cannot appear.

### Live example — `0x37cc13650d0D2A73E181cbF48A1847AE5f0531b5`

| | LP amount | BB minted | truncated |
|---|---|---|---|
| deposit @ block 38022377 | 2146701100755580030478 | 686944352241785609752 | 96 |
| deposit @ block 38625159 | 485633753042731023542 | 155402800973673927533 | 44 |
| **total** | **2632334853798311054020** | **842347153215459537285** | 140 → **1 unit lost** |

`floor(2632334853798311054020 × 32 / 100) = 842347153215459537286` — one wei more BB than exists.

**3 of 17 active depositors are currently affected** (~3031.95 BUTTER). The other 14 have no shortfall yet but would hit this on their next deposit. No funds were ever lost — staked balances still sum exactly to the LP the contract holds.

## Fix

Both sides now move by the **difference of scaled balances** rather than scaling the delta, so an account's holding stays equal to its scaled staked balance after every operation and a full exit always burns exactly what was minted:

```solidity
// _deposit
_mint(_account, _scaledBalance(newBalance, _lp) - _scaledBalance(previousBalance, _lp));

// _withdraw
_burnUpToBalance(_account, _scaledBalance(previousBalance, _lp) - _scaledBalance(newBalance, _lp));
```

`_syncVotingWeight` had the same floor-of-difference flaw and now scales each side before subtracting.

Burns are capped at the account's balance via `_burnUpToBalance`. This is what lets the **already-affected positions** exit: delta arithmetic alone keeps their pre-existing shortfall intact, so without the cap the three accounts above would still revert. For any deposit made under the new accounting the requested amount is already covered, so the cap never applies.

**No storage changes** — `bread`, `allowlistedLPs`, `scalingFactors`, and `_accountToLPData` keep their slots, so the upgrade is layout-safe and needs no migration.

## Testing

`104/104` passing. New coverage:

**`ButteredBreadTest_WithdrawRounding`** — replicates the incident against a fresh proxy:
- `testWithdrawFullBalanceAfterTwoDeposits` uses the exact on-chain deposit amounts at factor 32. Before the fix it reproduced the mainnet revert byte-for-byte: `ERC20InsufficientBalance(..., 842347153215459537285, 842347153215459537286)`.
- `testWithdrawFullBalanceFractionalFactor` shows the bug is **not** specific to the sub-100 factor — it also occurs at `132`, which satisfies the documented `>= FIXED_POINT_PERCENT` invariant.
- `testMintedSupplyMatchesAggregateEntitlement`, `testDustWithdrawalDoesNotRetainVotingWeight`, and two fuzz tests over arbitrary deposit/withdrawal splits and factors 1–10000.

**`ButteredBreadUpgradeTest`** — forks Gnosis at block 47651977 and upgrades the **live proxy**:
- `testFullWithdrawRevertsBeforeUpgrade` confirms all three accounts genuinely revert today.
- `testFullWithdrawSucceedsAfterUpgrade` confirms each recovers its **entire** staked balance in a **single call**.
- `testUpgradePreservesExistingState` asserts total supply, LP holdings, scaling factor, and every position are untouched by the upgrade.

All five previously-failing regression tests fail on `dev` and pass here.

### One pre-existing assertion changed

`ButteredBreadTest_Fuzz.testWithdrawAndBurn` asserted `balanceOf == preWithdrawBalance - floor(withdrawal × factor / 100)`, which encodes the old arithmetic and is off by one under the fix. It now asserts the invariant directly:

```solidity
assertEq(bb.balanceOf(ALICE), remainingBalance * _s.initialFactor / fixedPointPercent);
```

This is strictly stronger — it pins the holding to the scaled remainder rather than to a delta.

## Recovery without waiting for this upgrade

Affected users can exit today by withdrawing just under the max, then the dust. Verified on a fork; each recovers 100%:

```
0x37cc…31b5:  withdraw(lp, 2632334853798311054018)  then  withdraw(lp, 2)
0x18a7…8879:  withdraw(lp, 295991869687105715003)   then  withdraw(lp, 3)  then  withdraw(lp, 1)
0xcf26…1bf1:  withdraw(lp, 103620399017327657862)   then  withdraw(lp, 2)
```

Step 1 is `min(staked, (bb_balance × 100 + 99) / 32)`. Follow-up chunks must be ≤ 3 wei each, since `floor(4 × 32 / 100) = 1` with no BB left to burn.

## Left out of scope — worth separate decisions

1. **Is `32` the intended factor?** It means depositors receive **0.32×**, contradicting the documented `100 = 1X, 150 = 1.5X` semantics — possibly a missing zero. `initialize` has no `>= FIXED_POINT_PERCENT` guard while `modifyScalingFactor` does, so production sits at a value it can no longer be set back to. This PR makes the arithmetic correct for *any* factor and deliberately does not change the economics or add the guard, since that's a policy call.

2. **`modifyAllowList(lp, false)` also gates `withdraw`.** Delisting an LP would freeze every existing position in it. Dropping `onlyAllowed` from the withdraw path would keep exits open unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
