### PR TITLE
fix: voting security — multipliers, streak spam, distributeYieldGK

### DIFF
--- a/src/VotingMultipliers.sol
+++ b/src/VotingMultipliers.sol
@@ -116,11 +116,17 @@ contract VotingMultipliers is Ownable2StepUpgradeable, IVotingMultipliers {
 
         uint256 _totalMultiplier = MultiplierConstants.BASE_MULTIPLIER;
 
+        // Track seen indexes so the same allowlisted multiplier cannot be stacked
+        // by repeating its index (issue #186).
+        bool[] memory _seen = new bool[]($.allowlistedMultipliers.length);
+
         for (uint256 i = 0; i < _multiplierIndexes.length; i++) {
             uint256 index = _multiplierIndexes[i];
             if (index >= $.allowlistedMultipliers.length) {
                 revert InvalidMultiplierIndex();
             }
+            if (_seen[index]) revert DuplicateMultiplierIndex();
+            _seen[index] = true;
 
             IMultiplier multiplier = $.allowlistedMultipliers[index];
             multiplier.updateMultiplyingFactor(_user);

--- a/src/YieldDistributor.sol
+++ b/src/YieldDistributor.sol
@@ -77,6 +77,9 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
     mapping(uint256 => address) public voterAtIndex;
     /// @notice Mapping from voter address to the cycle they last voted in
     mapping(address => uint256) public voterVotedCycle;
+    /// @notice Effective voting power (including multipliers) recorded at cast time
+    /// @dev Used by distributeYieldGK so it cannot bypass multipliers (issue #184)
+    mapping(address => uint256) internal _voterEffectivePower;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -441,6 +444,7 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
         }
 
         accountLastVoted[_account] = block.number;
+        _voterEffectivePower[_account] = _votingPower;
 
         emit BreadHolderVoted(_account, _points, projects);
     }
@@ -459,7 +463,12 @@ contract YieldDistributor is IYieldDistributor, Ownable2StepUpgradeable, VotingM
 
         for (uint256 i; i < votersCount; ++i) {
             address _voter = voterAtIndex[i];
-            uint256 _voterPower = getCurrentVotingPower(_voter);
+            // Prefer effective power stored at cast time (includes multipliers).
+            // Fall back to raw power only if unset (should not happen for current voters).
+            uint256 _voterPower = _voterEffectivePower[_voter];
+            if (_voterPower == 0) {
+                _voterPower = getCurrentVotingPower(_voter);
+            }
             uint256[] memory _voterDistribution = _holderToDistribution[_voter];
             uint256 _vote;
             for (uint256 j; j < projects.length; ++j) {

--- a/src/interfaces/IVotingMultipliers.sol
+++ b/src/interfaces/IVotingMultipliers.sol
@@ -12,6 +12,8 @@ interface IVotingMultipliers {
     error MultiplierNotAllowlisted();
     /// @notice Thrown when an invalid multiplier index is provided
     error InvalidMultiplierIndex();
+    /// @notice Thrown when a duplicate multiplier index is provided (issue #186)
+    error DuplicateMultiplierIndex();
 
     /// @notice Emitted when a new multiplier is added to the allowlist
     /// @param multiplier The address of the added multiplier

--- a/src/multipliers/VotingStreakMultiplier.sol
+++ b/src/multipliers/VotingStreakMultiplier.sol
@@ -29,6 +29,10 @@ contract VotingStreakMultiplier is Initializable, OwnableUpgradeable, IMultiplie
     /// @notice Mapping of user addresses to their multiplier validity period
     mapping(address => uint256) public userToValidUntil;
 
+    /// @notice lastClaimedBlockNumber of the cycle when the user's streak was last incremented
+    /// @dev Prevents maxing the streak in one cycle by spamming updateMultiplyingFactor (issue #185)
+    mapping(address => uint256) public userLastUpdatedCycle;
+
     /// @notice Error emitted when an invalid multiplier increment is provided
     error InvalidMultiplierIncrement();
 
@@ -94,6 +98,12 @@ contract VotingStreakMultiplier is Initializable, OwnableUpgradeable, IMultiplie
             return;
         }
 
+        // At most one streak increment per distribution cycle (issue #185).
+        // lastClaimedBlockNumber advances each distribute, so it identifies the cycle.
+        if (userLastUpdatedCycle[_user] == lastClaimedBlock) {
+            return;
+        }
+
         uint256 currentMultiplier = getMultiplyingFactor(_user);
         uint256 newMultiplier = (currentMultiplier == MultiplierConstants.BASE_MULTIPLIER)
             ? MultiplierConstants.BASE_MULTIPLIER + multiplierIncrement
@@ -102,6 +112,7 @@ contract VotingStreakMultiplier is Initializable, OwnableUpgradeable, IMultiplie
                 (MultiplierConstants.BASE_MULTIPLIER + (maxMultiplierIncrements * multiplierIncrement))
             );
 
+        userLastUpdatedCycle[_user] = lastClaimedBlock;
         userToMultiplier[_user] = newMultiplier;
         userToValidUntil[_user] = lastClaimedBlock + (2 * cycleLength);
         emit MultiplierUpdated(_user, newMultiplier, userToValidUntil[_user]);

--- a/test/YieldDistributor.t.sol
+++ b/test/YieldDistributor.t.sol
@@ -813,6 +813,30 @@ contract VotingStreakMultiplierTest is YieldDistributorTest {
         assertEq(multiplier.getMultiplyingFactor(testAccount), baseMultiplier + multiplier.multiplierIncrement());
     }
 
+    /// @notice Issue #185: spam updateMultiplyingFactor must not max the streak in one cycle
+    function test_updateMultiplyingFactor_oncePerCycle() public {
+        VotingStreakMultiplier multiplier = setUpVotingStreakMultiplier();
+        address testAccount = setUpTestAccount();
+        uint256 baseMultiplier = 1e18;
+        setUpForCycle(yieldDistributor, 0);
+
+        assertEq(multiplier.getMultiplyingFactor(testAccount), baseMultiplier);
+
+        multiplier.updateMultiplyingFactor(testAccount);
+        uint256 afterFirst = multiplier.userToMultiplier(testAccount);
+        assertEq(afterFirst, baseMultiplier + multiplier.multiplierIncrement());
+
+        multiplier.updateMultiplyingFactor(testAccount);
+        uint256 afterSecond = multiplier.userToMultiplier(testAccount);
+        assertEq(afterSecond, afterFirst, "Multiplier should not change on second call in same cycle");
+
+        // Spam further — still no-op
+        for (uint256 i = 0; i < 10; i++) {
+            multiplier.updateMultiplyingFactor(testAccount);
+        }
+        assertEq(multiplier.userToMultiplier(testAccount), afterFirst);
+    }
+
     function test_set_invalid_multiplier_increment() public {
         VotingStreakMultiplier multiplier = setUpVotingStreakMultiplier();
 
@@ -1197,6 +1221,57 @@ contract VotingMultipliersTest is YieldDistributorTest {
         // Total should still be the same
         uint256 totalAfterRevote = yieldDistributor2.currentVotes();
         assertEq(totalAfterRevote, voter1Power + voter2Power, "Total should remain sum of both voters after revote");
+    }
+
+    /// @notice Issue #186: repeating the same multiplier index must revert
+    function test_castVoteWithMultipliers_duplicateIndex_reverts() public {
+        yieldDistributor.addMultiplier(IMultiplier(address(mockMultiplier1)));
+
+        address voter = address(0x1);
+        address[] memory voters = new address[](1);
+        voters[0] = voter;
+        setUpAccountsForVoting(voters);
+        setUpForCycle(yieldDistributor);
+
+        uint256[] memory points = new uint256[](1);
+        points[0] = 100;
+        uint256[] memory multiplierIndices = new uint256[](2);
+        multiplierIndices[0] = 0;
+        multiplierIndices[1] = 0;
+
+        vm.prank(voter);
+        vm.expectRevert(IVotingMultipliers.DuplicateMultiplierIndex.selector);
+        yieldDistributor.castVoteWithMultipliers(points, multiplierIndices);
+    }
+
+    /// @notice Issue #184: distributeYieldGK must use effective (multiplied) power
+    function test_distributeYieldGK_UsesEffectiveVotingPowerWithMultipliers() public {
+        address voter = address(0x1234567890123456789012345678901234567890);
+        address[] memory accounts = new address[](1);
+        accounts[0] = voter;
+        setUpAccountsForVoting(accounts);
+        setUpForCycle(yieldDistributorGasKiller);
+
+        MockMultiplier mockMult = new MockMultiplier();
+        mockMult.setMultiplier(2e18, type(uint256).max);
+        yieldDistributorGasKiller.addMultiplier(IMultiplier(address(mockMult)));
+
+        uint256[] memory points = new uint256[](1);
+        points[0] = 100;
+        uint256[] memory multiplierIndices = new uint256[](1);
+        multiplierIndices[0] = 0;
+
+        vm.prank(voter);
+        yieldDistributorGasKiller.castVoteWithMultipliers(points, multiplierIndices);
+
+        uint256 rawPower = yieldDistributorGasKiller.getCurrentVotingPower(voter);
+        uint256 effectivePower = yieldDistributorGasKiller.currentVotes();
+        assertEq(effectivePower, (rawPower * 2e18) / yieldDistributorGasKiller.PRECISION());
+
+        uint256 balBefore = bread.balanceOf(address(this));
+        yieldDistributorGasKiller.distributeYieldGK();
+        uint256 balAfter = bread.balanceOf(address(this));
+        assertGt(balAfter, balBefore, "Project should receive yield");
     }
 
     function test_stateTransitionCount_IncrementsOnStateMutatingFunctions() public {

--- a/test/YieldDistributor.t.sol
+++ b/test/YieldDistributor.t.sol
@@ -1245,33 +1245,62 @@ contract VotingMultipliersTest is YieldDistributorTest {
     }
 
     /// @notice Issue #184: distributeYieldGK must use effective (multiplied) power
+    /// @dev Multi-project relative shares prove GK reads stored effective power. With one
+    ///      project, payout is independent of voter weight so a raw-power reversion still passes.
     function test_distributeYieldGK_UsesEffectiveVotingPowerWithMultipliers() public {
-        address voter = address(0x1234567890123456789012345678901234567890);
-        address[] memory accounts = new address[](1);
-        accounts[0] = voter;
+        address voterWithMult = address(0x1234567890123456789012345678901234567890);
+        address voterNoMult = address(0xabCDEF1234567890ABcDEF1234567890aBCDeF12);
+        address[] memory accounts = new address[](2);
+        accounts[0] = voterWithMult;
+        accounts[1] = voterNoMult;
         setUpAccountsForVoting(accounts);
-        setUpForCycle(yieldDistributorGasKiller);
+        setUpForCycle(yieldDistributor2);
 
         MockMultiplier mockMult = new MockMultiplier();
         mockMult.setMultiplier(2e18, type(uint256).max);
-        yieldDistributorGasKiller.addMultiplier(IMultiplier(address(mockMult)));
+        yieldDistributor2.addMultiplier(IMultiplier(address(mockMult)));
 
-        uint256[] memory points = new uint256[](1);
-        points[0] = 100;
+        uint256 rawPower = yieldDistributor2.getCurrentVotingPower(voterWithMult);
+        assertEq(yieldDistributor2.getCurrentVotingPower(voterNoMult), rawPower, "Voters need equal raw power");
+
+        // 2x-multiplied voter sends all weight to project 0; plain voter to project 1
+        uint256[] memory pointsMult = new uint256[](2);
+        pointsMult[0] = 100;
+        pointsMult[1] = 0;
         uint256[] memory multiplierIndices = new uint256[](1);
         multiplierIndices[0] = 0;
+        vm.prank(voterWithMult);
+        yieldDistributor2.castVoteWithMultipliers(pointsMult, multiplierIndices);
 
-        vm.prank(voter);
-        yieldDistributorGasKiller.castVoteWithMultipliers(points, multiplierIndices);
+        uint256[] memory pointsPlain = new uint256[](2);
+        pointsPlain[0] = 0;
+        pointsPlain[1] = 100;
+        vm.prank(voterNoMult);
+        yieldDistributor2.castVote(pointsPlain);
 
-        uint256 rawPower = yieldDistributorGasKiller.getCurrentVotingPower(voter);
-        uint256 effectivePower = yieldDistributorGasKiller.currentVotes();
-        assertEq(effectivePower, (rawPower * 2e18) / yieldDistributorGasKiller.PRECISION());
+        uint256 effectivePower = (rawPower * 2e18) / yieldDistributor2.PRECISION();
+        assertEq(
+            yieldDistributor2.currentVotes(),
+            effectivePower + rawPower,
+            "currentVotes should sum 2x + 1x effective power"
+        );
 
-        uint256 balBefore = bread.balanceOf(address(this));
-        yieldDistributorGasKiller.distributeYieldGK();
-        uint256 balAfter = bread.balanceOf(address(this));
-        assertGt(balAfter, balBefore, "Project should receive yield");
+        uint256 yieldAccrued = bread.yieldAccrued();
+        uint256 fixedPerProject = (yieldAccrued / _yieldFixedSplitDivisor) / 2;
+        uint256 bal0Before = bread.balanceOf(address(this));
+        uint256 bal1Before = bread.balanceOf(secondProject);
+
+        yieldDistributor2.distributeYieldGK();
+
+        uint256 received0 = bread.balanceOf(address(this)) - bal0Before;
+        uint256 received1 = bread.balanceOf(secondProject) - bal1Before;
+        uint256 voted0 = received0 - fixedPerProject;
+        uint256 voted1 = received1 - fixedPerProject;
+
+        // If GK recomputed from raw power, both projects would get equal voted yield.
+        // With stored 2x effective power, project 0's voted share must be ~2x project 1's.
+        assertGt(voted0, voted1, "2x effective power must favor project 0 over project 1");
+        assertApproxEqAbs(voted0, voted1 * 2, marginOfError * 2);
     }
 
     function test_stateTransitionCount_IncrementsOnStateMutatingFunctions() public {

--- a/test/upgrades/latest/ButteredBread.sol
+++ b/test/upgrades/latest/ButteredBread.sol
@@ -3682,7 +3682,8 @@ library Bytes {
     /// @dev Same as {reverseBytes32} but optimized for 128-bit values.
     function reverseBytes16(bytes16 value) internal pure returns (bytes16) {
         value = // swap bytes
-             ((value & 0xFF00FF00FF00FF00FF00FF00FF00FF00) >> 8) | ((value & 0x00FF00FF00FF00FF00FF00FF00FF00FF) << 8);
+                ((value & 0xFF00FF00FF00FF00FF00FF00FF00FF00) >> 8)
+                | ((value & 0x00FF00FF00FF00FF00FF00FF00FF00FF) << 8);
         value = // swap 2-byte long pairs
                 ((value & 0xFFFF0000FFFF0000FFFF0000FFFF0000) >> 16)
                 | ((value & 0x0000FFFF0000FFFF0000FFFF0000FFFF) << 16);


### PR DESCRIPTION
## Summary
Fixes the Tier A voting-power bugs:

- **#186** — reject duplicate multiplier indexes in `calculateTotalMultipliers` (`DuplicateMultiplierIndex`)
- **#185** — at most one `VotingStreakMultiplier` increment per cycle (keyed by `lastClaimedBlockNumber`)
- **#184** — store effective (multiplied) power at cast time so `distributeYieldGK` / `_computeVotedDistribution` cannot recompute raw power and bypass multipliers

## Root causes
1. Multiplier indexes were not uniqueness-checked → stack the same NFT/streak bonus.
2. Streak only blocked updates after voting, not repeated pre-vote calls in the same cycle.
3. `distributeYieldGK` recomputed `getCurrentVotingPower` (raw) instead of the power used when casting with multipliers.

## Related open PRs
Overlaps with #196 / #197 / #198 (Tranquil-Flow). Happy to close this in favor of those or land whichever is reviewed first — this PR packages all three with regression tests in one branch.

## Test plan
- [x] `forge test --match-test "duplicateIndex|oncePerCycle|UsesEffectiveVotingPower"` (GNOSIS_RPC_URL) — 3 pass
- [x] `VotingMultipliersTest` / `VotingStreakMultiplierTest` non-fuzz cases pass (fuzz failures observed were publicnode 429 rate limits, not logic)
- [ ] Review storage layout note: new mappings appended at end of `VotingStreakMultiplier` / `YieldDistributor` for upgrade safety