### PR TITLE
fix: account for fee-on-transfer LP deposits in ButteredBread

### DIFF
--- a/src/ButteredBread.sol
+++ b/src/ButteredBread.sol
@@ -141,20 +141,24 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, Ownable2StepUpg
         return _accountToLPData[_holder][_lp];
     }
 
-    /// @notice Deposit LP tokens and mint ButteredBread with corresponding LP scaling factor
+    /// @notice Deposit LP tokens and mint ButteredBread with corresponding LP scaling factor.
+    ///         For fee-on-transfer tokens, mints based on actual received amount, not requested amount.
     function _deposit(address _account, address _lp, uint256 _amount) internal {
+        uint256 balanceBefore = IERC20(_lp).balanceOf(address(this));
         bool success = IERC20(_lp).transferFrom(_account, address(this), _amount);
         if (!success) revert TransferFailed();
+
+        uint256 actualReceivedAmount = IERC20(_lp).balanceOf(address(this)) - balanceBefore;
 
         _syncDelegation(_account);
 
         /// @dev ensure proper accounting in case of admin error in `modifyScalingFactor` where not all holders are updated
         _syncVotingWeight(_account, _lp);
-        _accountToLPData[_account][_lp].balance += _amount;
+        _accountToLPData[_account][_lp].balance += actualReceivedAmount;
 
-        _mint(_account, _amount * scalingFactors[_lp] / FIXED_POINT_PERCENT);
+        _mint(_account, actualReceivedAmount * scalingFactors[_lp] / FIXED_POINT_PERCENT);
 
-        emit ButterAdded(_account, _lp, _amount);
+        emit ButterAdded(_account, _lp, actualReceivedAmount);
     }
 
     /// @notice Withdraw LP tokens and burn ButteredBread with corresponding LP scaling factor

--- a/src/ButteredBread.sol
+++ b/src/ButteredBread.sol
@@ -77,8 +77,10 @@ contract ButteredBread is IButteredBread, ERC20VotesUpgradeable, Ownable2StepUpg
     /**
      * @notice Deposit LP tokens and mint ButteredBread
      *  NOTE: Additional ButteredBread can be minted/burned due to scaling factor changes
+     *  NOTE: For fee-on-transfer tokens, minting and LP balance accounting use the actual
+     *        amount received after transferFrom, not the requested `_amount`
      * @param _lp Liquidity Pool token
-     * @param _amount Value of LP token
+     * @param _amount Amount of LP token to transferFrom the caller
      */
     function deposit(address _lp, uint256 _amount) external onlyAllowed(_lp) nonReentrant {
         if (_amount == 0) revert AmountZero();

--- a/src/interfaces/IButteredBread.sol
+++ b/src/interfaces/IButteredBread.sol
@@ -23,6 +23,7 @@ interface IButteredBread {
     error AmountZero();
 
     /// @notice The event emitted when an LP Token (Butter) has been added
+    /// @dev `_amount` is the LP balance actually credited (actual tokens received after transferFrom)
     event ButterAdded(address _account, address _lp, uint256 _amount);
     /// @notice The event emitted when an LP Token (Butter) has been removed
     event ButterRemoved(address _account, address _lp, uint256 _amount);
@@ -67,6 +68,7 @@ interface IButteredBread {
     function accountToLPBalance(address _account, address _lp) external view returns (uint256 _balance);
 
     /// @notice Deposits LP tokens (Butter) and mints `ButteredBread` according to the respective LP scaling factor
+    /// @dev Minting and balance accounting use the actual balance delta after transferFrom (fee-on-transfer safe)
     function deposit(address _lp, uint256 _amount) external;
 
     /// @notice Withdraws some amount of Butter (LP token) and burns an amount of the user's `ButteredBread` according to the respective scaling factor

--- a/src/test/FeeOnTransferERC20.sol
+++ b/src/test/FeeOnTransferERC20.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.25;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @notice Mock ERC20 that deducts a percentage fee on every transfer (fee is burned)
+contract FeeOnTransferERC20 is ERC20 {
+    uint256 public feePercent;
+
+    constructor(uint256 _feePercent) ERC20("FeeOnTransfer", "FOT") {
+        feePercent = _feePercent;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        if (from != address(0) && to != address(0)) {
+            uint256 fee = value * feePercent / 100;
+            // Transfer (value - fee) to recipient, then burn the fee from sender
+            super._update(from, to, value - fee);
+            super._update(from, address(0), fee);
+        } else {
+            super._update(from, to, value);
+        }
+    }
+}

--- a/test/ButteredBread.t.sol
+++ b/test/ButteredBread.t.sol
@@ -16,6 +16,7 @@ import {ICurveStableSwap} from "src/interfaces/ICurveStableSwap.sol";
 import {IERC20Votes} from "src/interfaces/IERC20Votes.sol";
 import {YieldDistributorTestWrapper} from "src/test/YieldDistributorTestWrapper.sol";
 import {YieldDistributor, IYieldDistributor} from "src/YieldDistributor.sol";
+import {FeeOnTransferERC20} from "src/test/FeeOnTransferERC20.sol";
 
 uint256 constant XDAI_FACTOR = 700; // 700% scaling factor; 7X
 uint256 constant TOKEN_AMOUNT = 1000 ether;
@@ -577,5 +578,116 @@ contract ButteredBreadTest_Integration is ButteredBreadTest {
         uint256 bbBalance = bb.balanceOf(ALICE);
         uint256 bBalance = IERC20(GNOSIS_BREAD).balanceOf(ALICE);
         assertEq(yieldDistributor.getCurrentVotingPower(ALICE), bbBalance + bBalance);
+    }
+}
+
+/// @notice Tests for issue #187: fee-on-transfer token accounting
+contract ButteredBreadTest_FeeOnTransfer is ButteredBreadTest {
+    FeeOnTransferERC20 public fotToken;
+    uint256 public constant FEE_PERCENT = 5;
+    uint256 public constant FOT_FACTOR = 200; // 2X scaling
+
+    function setUp() public virtual override {
+        super.setUp();
+        fotToken = new FeeOnTransferERC20(FEE_PERCENT);
+
+        address[] memory emptyList = new address[](0);
+        bb.modifyScalingFactor(address(fotToken), FOT_FACTOR, emptyList);
+        bb.modifyAllowList(address(fotToken), true);
+    }
+
+    function _setupFotDepositor(address _account, uint256 _amount) internal {
+        fotToken.mint(_account, _amount);
+        vm.prank(_account);
+        fotToken.approve(address(bb), _amount);
+    }
+
+    /// @notice Deposit should record actual received amount, not requested amount
+    function testDepositAccountsForTransferFee() public {
+        uint256 depositAmount = 1000 ether;
+        uint256 expectedReceived = depositAmount - (depositAmount * FEE_PERCENT / 100);
+
+        _setupFotDepositor(ALICE, depositAmount);
+
+        vm.prank(ALICE);
+        bb.deposit(address(fotToken), depositAmount);
+
+        uint256 recordedBalance = bb.accountToLPBalance(ALICE, address(fotToken));
+        assertEq(recordedBalance, expectedReceived, "Recorded balance should equal actual received amount");
+
+        uint256 contractBalance = fotToken.balanceOf(address(bb));
+        assertEq(contractBalance, expectedReceived, "Contract token balance should match recorded balance");
+
+        uint256 expectedBB = expectedReceived * FOT_FACTOR / fixedPointPercent;
+        assertEq(bb.balanceOf(ALICE), expectedBB, "BB minted should be based on actual received amount");
+    }
+
+    /// @notice Multiple depositors should not allow early withdrawers to drain the contract
+    function testFeeOnTransferPreventsImbalancedWithdrawals() public {
+        uint256 aliceDeposit = 1000 ether;
+        uint256 bobbyDeposit = 1000 ether;
+        uint256 aliceReceived = aliceDeposit - (aliceDeposit * FEE_PERCENT / 100);
+        uint256 bobbyReceived = bobbyDeposit - (bobbyDeposit * FEE_PERCENT / 100);
+
+        _setupFotDepositor(ALICE, aliceDeposit);
+        _setupFotDepositor(BOBBY, bobbyDeposit);
+
+        vm.prank(ALICE);
+        bb.deposit(address(fotToken), aliceDeposit);
+
+        vm.prank(BOBBY);
+        bb.deposit(address(fotToken), bobbyDeposit);
+
+        assertEq(
+            fotToken.balanceOf(address(bb)),
+            aliceReceived + bobbyReceived,
+            "Contract should hold sum of actual received amounts"
+        );
+
+        uint256 aliceRecorded = bb.accountToLPBalance(ALICE, address(fotToken));
+        vm.prank(ALICE);
+        bb.withdraw(address(fotToken), aliceRecorded);
+
+        uint256 contractRemaining = fotToken.balanceOf(address(bb));
+        uint256 bobbyRecorded = bb.accountToLPBalance(BOBBY, address(fotToken));
+        assertGe(
+            contractRemaining, bobbyRecorded, "Contract must hold enough tokens for remaining depositors to withdraw"
+        );
+
+        vm.prank(BOBBY);
+        bb.withdraw(address(fotToken), bobbyRecorded);
+
+        assertEq(bb.accountToLPBalance(BOBBY, address(fotToken)), 0, "Bobby should have zero balance after withdrawal");
+    }
+
+    /// @notice Voting power (BB balance) should not be inflated beyond actual deposits
+    function testFeeOnTransferVotingPowerNotInflated() public {
+        uint256 depositAmount = 1000 ether;
+        uint256 expectedReceived = depositAmount - (depositAmount * FEE_PERCENT / 100);
+
+        _setupFotDepositor(ALICE, depositAmount);
+
+        vm.prank(ALICE);
+        bb.deposit(address(fotToken), depositAmount);
+
+        uint256 inflatedBB = depositAmount * FOT_FACTOR / fixedPointPercent;
+        uint256 correctBB = expectedReceived * FOT_FACTOR / fixedPointPercent;
+
+        assertEq(bb.balanceOf(ALICE), correctBB, "BB should reflect actual deposit");
+        assertLt(bb.balanceOf(ALICE), inflatedBB, "BB must be less than inflated amount");
+    }
+
+    /// @notice ButterAdded event should emit the actual received amount
+    function testFeeOnTransferEventEmitsActualAmount() public {
+        uint256 depositAmount = 1000 ether;
+        uint256 expectedReceived = depositAmount - (depositAmount * FEE_PERCENT / 100);
+
+        _setupFotDepositor(ALICE, depositAmount);
+
+        vm.expectEmit(true, true, false, true);
+        emit IButteredBread.ButterAdded(ALICE, address(fotToken), expectedReceived);
+
+        vm.prank(ALICE);
+        bb.deposit(address(fotToken), depositAmount);
     }
 }

--- a/test/upgrades/latest/ButteredBread.sol
+++ b/test/upgrades/latest/ButteredBread.sol
@@ -3682,7 +3682,8 @@ library Bytes {
     /// @dev Same as {reverseBytes32} but optimized for 128-bit values.
     function reverseBytes16(bytes16 value) internal pure returns (bytes16) {
         value = // swap bytes
-             ((value & 0xFF00FF00FF00FF00FF00FF00FF00FF00) >> 8) | ((value & 0x00FF00FF00FF00FF00FF00FF00FF00FF) << 8);
+                ((value & 0xFF00FF00FF00FF00FF00FF00FF00FF00) >> 8)
+                | ((value & 0x00FF00FF00FF00FF00FF00FF00FF00FF) << 8);
         value = // swap 2-byte long pairs
                 ((value & 0xFFFF0000FFFF0000FFFF0000FFFF0000) >> 16)
                 | ((value & 0x0000FFFF0000FFFF0000FFFF0000FFFF) << 16);


### PR DESCRIPTION
## Summary
Fixes **#187**: `ButteredBread._deposit` now records and mints from the **actual** token balance delta after `transferFrom`, not the requested amount.

## Root cause
Fee-on-transfer LPs deliver less than `_amount`. Accounting with `_amount` makes internal balances exceed holdings so early full withdraws can drain later depositors. Active only if a FoT pair is allowlisted.

## Related
Overlaps with #194 (`Ss251 fix/187…` by bagelface). Same approach (balance-before/after); this is a clean re-implementation on current `dev` with the FoT test suite.

## Test plan
- [x] `forge test --match-contract ButteredBreadTest_FeeOnTransfer` — 4 pass
  - deposit records actual received
  - multi-depositor withdraw cannot drain
  - BB voting power not inflated
  - `ButterAdded` emits actual amount